### PR TITLE
feat: Adding smithy model with the credential management APIs

### DIFF
--- a/src/smithy/README.md
+++ b/src/smithy/README.md
@@ -1,0 +1,14 @@
+# Genet Smithy Models
+
+The Genet Service Smithy model consists of:
+- Credential Management Service:
+  - `/tokens/installation` API endpoint:
+    - Retrieves the [installation access token](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app) for a specific App and target
+      installation from GitHub based on the App ID and the Node ID as input.
+  - `/tokens/app` API endpoint:
+    - Retrieves a [JWT token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app) for a GitHub App based on the App ID as input.
+
+To build the smithy model and generate the ssdk run the following commands:
+```
+smithy build
+```

--- a/src/smithy/model/credential_management.smithy
+++ b/src/smithy/model/credential_management.smithy
@@ -1,0 +1,71 @@
+namespace genet.api
+
+resource CredentialManagementService{
+    operations: [GetInstallationToken, GetAppToken]
+}
+
+@readonly
+@http(method: "GET", uri: "/tokens/installation")
+operation GetInstallationToken {
+    input: GetInstallationTokenInput,
+    output: GetInstallationTokenOutput
+    errors:[ServerSideError, AccessDeniedError, RateLimitError, GatewayTimeoutError]
+}
+
+structure GetInstallationTokenOutput {
+    installationToken: String
+}
+
+@readonly
+@http(method: "GET", uri: "/tokens/app")
+operation GetAppToken {
+    input: GetAppTokenInput,
+    output: GetAppTokenOutput
+    errors:[ServerSideError, AccessDeniedError, GatewayTimeoutError]
+}
+
+structure GetInstallationTokenInput {
+    @required
+    @httpQuery("appId")
+    appId: String
+
+    @required
+    @httpQuery("nodeId")
+    nodeId: String
+}
+
+structure GetAppTokenInput {
+    @required
+    @httpQuery("appId")
+    appId: String
+}
+
+structure GetAppTokenOutput {
+    appToken: String
+}
+
+@httpError(500)
+@error("server")
+structure ServerSideError {
+    message: String,
+}
+
+// Error that can occur when unable to access AWS resources
+@httpError(403)
+@error("client")
+structure AccessDeniedError {
+    message: String,
+}
+
+@httpError(429)
+@error("client")
+structure RateLimitError {
+    message: String,
+}
+
+// Error that can occur when unable to access AWS resources
+@httpError(504)
+@error("server")
+structure GatewayTimeoutError {
+    message: String,
+}

--- a/src/smithy/model/main.smithy
+++ b/src/smithy/model/main.smithy
@@ -1,0 +1,37 @@
+$version: "2.0"
+
+namespace genet.api
+
+use aws.auth#sigv4
+use aws.protocols#restJson1
+use smithy.framework#ValidationException
+
+@title("Genet Service")
+@auth([sigv4])
+@sigv4(name: "Genet")
+@restJson1
+service GenetService {
+    version: "2024-08-23"
+    resources: [
+        CredentialManagementService
+    ]
+    errors: [
+        ValidationException,
+        AccessDeniedError,
+        GatewayTimeoutError
+    ]
+}
+
+// Error that can occur when unable to access AWS resources
+@error("client")
+@httpError(403)
+structure AccessDeniedError {
+    message: String,
+}
+
+// Error that can occur when unable to access AWS resources
+@httpError(504)
+@error("server")
+structure GatewayTimeoutError {
+    message: String,
+}

--- a/src/smithy/smithy-build.json
+++ b/src/smithy/smithy-build.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0",
+    "sources": ["model/"],
+    "maven": {
+        "dependencies": [
+            "software.amazon.smithy:smithy-aws-traits:1.50.0",
+            "software.amazon.smithy:smithy-validation-model:1.50.0",
+            "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.22.0"
+        ]
+    },
+    "plugins": {
+        "typescript-ssdk-codegen": {
+            "package": "@genet.api/genet-ssdk-client",
+            "packageVersion": "0.0.1"
+        }
+    }
+}


### PR DESCRIPTION
### Notes
For the Credential Management service in Genet, added the following APIs:
  - `/tokens/installation` API endpoint:
    - Retrieves the [installation access token](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app) for a specific App and target
      installation from GitHub based on the App ID and the Node ID as input.
  - `/tokens/app` API endpoint:
    - Retrieves a [JWT token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app) for a GitHub App based on the App ID as input.

To build the smithy model and generate the ssdk run the following commands:
```
smithy build
```

### Testing

Ran the `smithy build` command and the model builds as expected.