### PR TITLE
fix: Changing App ID data type from String to Integer

### DIFF
--- a/src/packages/smithy/README.md
+++ b/src/packages/smithy/README.md
@@ -4,13 +4,13 @@ The Genet Service Smithy model consists of:
 
 - Credential Management Service:
 
-  - `GetInstallationToken` API endpoint:
+  - `/tokens/installation` API endpoint:
 
     - Retrieves the installation access token
       for a specific App and target installation from
       GitHub based on the App ID and the Node ID as input.
 
-  - `GetAppToken` API endpoint:
+  - `/tokens/app` API endpoint:
     - Retrieves a JWT token for a GitHub App based on the App ID as input.
 
 To build the smithy model and generate the ssdk run the following commands:

--- a/src/packages/smithy/model/credential_management.smithy
+++ b/src/packages/smithy/model/credential_management.smithy
@@ -5,7 +5,7 @@ resource CredentialManagementService{
 }
 
 // Placeholder API endpoints
-@http(method: "POST", uri: "/example.com")
+@http(method: "POST", uri: "/tokens/installation")
 operation GetInstallationToken {
     input: GetInstallationTokenInput,
     output: GetInstallationTokenOutput
@@ -13,7 +13,7 @@ operation GetInstallationToken {
 }
 
 // Placeholder API endpoints
-@http(method: "POST", uri: "/example.net")
+@http(method: "POST", uri: "/tokens/app")
 operation GetAppToken {
     input: GetAppTokenInput,
     output: GetAppTokenOutput


### PR DESCRIPTION
### Notes
Changed `appID` type to Integer from String and changed APIs from `GET` to `POST` due to body parameters for API requests.

### Testing
Compiles successfully from `smithy build`
