### PR TITLE
fix: Adding back Validation checks in smithy model

### DIFF
--- a/src/packages/smithy/model/main.smithy
+++ b/src/packages/smithy/model/main.smithy
@@ -4,6 +4,7 @@ namespace framework.api
 
 use aws.auth#sigv4
 use aws.protocols#restJson1
+use smithy.framework#ValidationException
 
 @title("Framework for GitHub Apps on AWS")
 @auth([sigv4])
@@ -15,6 +16,7 @@ service AppFramework {
         CredentialManagementService
     ]
     errors: [
+        ValidationException
         AccessDeniedError,
         GatewayTimeoutError,
         ServiceUnavailableError

--- a/src/packages/smithy/smithy-build.json
+++ b/src/packages/smithy/smithy-build.json
@@ -11,8 +11,7 @@
     "plugins": {
         "typescript-ssdk-codegen": {
             "package": "@framework.api/app-framework-ssdk",
-            "packageVersion": "0.0.1",
-            "disableDefaultValidation": true
+            "packageVersion": "0.0.1"
         }
     }
 }


### PR DESCRIPTION
### Notes
Adding back in ValidationException errors since they are helpful in checking API call paths when calling Lambda function urls, hence enabling default validation.

### Testing
Smithy build passes.