### PR TITLE
feat: adding a proof-of-concept for how to call using smithy-generated client

### DIFF
--- a/src/packages/app-framework-test-app/test/smithy-client.test.ts
+++ b/src/packages/app-framework-test-app/test/smithy-client.test.ts
@@ -1,0 +1,23 @@
+import {
+  AppFrameworkClient,
+  GetAppTokenCommand,
+} from '@aws/app-framework-client';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+
+// This test is skipped by default;
+// we need to wire in the Lambda function endpoint
+// which will likely differ for every AppFramework user.
+test.skip('Smithy client for app token API', async () => {
+  const client = new AppFrameworkClient({
+    // Update here.
+    endpoint:
+      'https://your-credential-manager-lambda-function-endpoint.lambda-url.us-west-2.on.aws/',
+    region: 'us-west-2',
+    credentials: defaultProvider(),
+    sha256: Sha256,
+  });
+  // Update here.
+  const command = new GetAppTokenCommand({ appId: 123456 });
+  await client.send(command);
+});


### PR DESCRIPTION
This is an example test for customers to see how to make calls using a Typescript generated client; along with the dependencies in the `projen` configuration required for the test.