### PR TITLE
feat: Adding in extra logging for APIs and adding in exporationTimest…

### DIFF
--- a/src/packages/app-framework/src/credential-manager/get-app-token/appToken.handler.ts
+++ b/src/packages/app-framework/src/credential-manager/get-app-token/appToken.handler.ts
@@ -8,7 +8,12 @@ import {
   GetAppTokenOutput,
   ServerSideError,
 } from '@framework.api/app-framework-ssdk';
-import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import {
+  APIGatewayEventRequestContextIAMAuthorizer,
+  APIGatewayEventRequestContextV2WithAuthorizer,
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResultV2,
+} from 'aws-lambda';
 import { EnvironmentVariables } from './constants';
 import { getAppTokenOperation as getAppTokenOperationImpl } from './getAppTokenOperation';
 import { EnvironmentError } from '../../error';
@@ -18,6 +23,9 @@ import { EnvironmentError } from '../../error';
 export const handler = async (
   event: APIGatewayProxyEventV2,
 ): Promise<APIGatewayProxyResultV2> => {
+  const context =
+    event.requestContext as APIGatewayEventRequestContextV2WithAuthorizer<APIGatewayEventRequestContextIAMAuthorizer>;
+  console.log('Caller Identity:', context.authorizer.iam.userArn);
   return handlerImpl({ event });
 };
 

--- a/src/packages/app-framework/src/credential-manager/get-app-token/getAppToken.ts
+++ b/src/packages/app-framework/src/credential-manager/get-app-token/getAppToken.ts
@@ -18,7 +18,7 @@ export type GetAppToken = ({
   getAppKeyArnbyId?: GetAppKeyArnById;
   kmsSign?: KmsSign;
   validateAppToken?: ValidateAppToken;
-}) => Promise<string>;
+}) => Promise<{ appToken: string; expiration_time: Date }>;
 /**
  * Generates a signed App Token using AWS KMS and validates it against the GitHub App API.
  *
@@ -41,15 +41,17 @@ export const getAppTokenImpl: GetAppToken = async ({
   kmsSign = kmsSignImpl,
   validateAppToken = validateAppTokenImpl,
 }) => {
+  console.log('App ID: ', appId);
   try {
     const header = {
       alg: 'RS256',
       typ: 'JWT',
     };
     const now = Math.floor(Date.now() / 1000);
+    const exp = now + 10 * 60;
     const payload = {
       iat: now - 60,
-      exp: now + 10 * 60,
+      exp,
       iss: appId,
     };
     const encodedHeader = Buffer.from(JSON.stringify(header)).toString(
@@ -64,7 +66,11 @@ export const getAppTokenImpl: GetAppToken = async ({
     const encodedSignature = signature.toString('base64url');
     const appToken = `${signingInput}.${encodedSignature}`;
     await validateAppToken({ appId, appToken });
-    return appToken;
+    console.log(
+      'App Token:',
+      encodeURIComponent(createHash('sha256').update(appToken).digest('hex')),
+    );
+    return { appToken, expiration_time: new Date(exp * 1000) };
   } catch (error) {
     if (error instanceof VisibleError) {
       throw error;

--- a/src/packages/app-framework/src/credential-manager/get-app-token/getAppTokenOperation.ts
+++ b/src/packages/app-framework/src/credential-manager/get-app-token/getAppTokenOperation.ts
@@ -33,7 +33,8 @@ export const getAppTokenOperation: Operation<
     });
     return {
       appId,
-      appToken,
+      appToken: appToken.appToken,
+      expirationTime: appToken.expiration_time,
     };
   } catch (error) {
     if (error instanceof VisibleError) {

--- a/src/packages/app-framework/src/credential-manager/get-installation-access-token/getInstallationAccessToken.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installation-access-token/getInstallationAccessToken.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { GetInstallationTokenOutput } from '@framework.api/app-framework-ssdk';
 import {
   GetInstallationIdFromTable,
@@ -58,16 +59,27 @@ export const getInstallationAccessTokenImpl: GetInstallationAccessToken =
         appId: appId,
         nodeId: nodeId,
         installationTable: installationTable,
-        appToken,
+        appToken: appToken.appToken,
       });
-      const githubService = new GitHubAPIService({ appToken });
+      const githubService = new GitHubAPIService({
+        appToken: appToken.appToken,
+      });
       const installationAccessToken = await githubService.getInstallationToken({
         installationId: installationID,
       });
+      console.log(
+        'Installation Access Token:',
+        encodeURIComponent(
+          createHash('sha256')
+            .update(installationAccessToken.token)
+            .digest('hex'),
+        ),
+      );
       return {
         appId: appId,
         nodeId: nodeId,
         installationToken: installationAccessToken.token,
+        expirationTime: new Date(installationAccessToken.expires_at),
       };
     } catch (error) {
       console.error(error);

--- a/src/packages/app-framework/src/credential-manager/get-installation-access-token/index.handler.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installation-access-token/index.handler.ts
@@ -8,8 +8,9 @@ import {
   getGetInstallationTokenHandler,
 } from '@framework.api/app-framework-ssdk';
 import {
+  APIGatewayEventRequestContextIAMAuthorizer,
+  APIGatewayEventRequestContextV2WithAuthorizer,
   APIGatewayProxyEventV2,
-  APIGatewayProxyResult,
   APIGatewayProxyResultV2,
 } from 'aws-lambda';
 import { InstallationAccessTokenEnvironmentVariables } from './constants';
@@ -22,6 +23,9 @@ import { EnvironmentError } from '../../error';
 export const handler = async (
   event: APIGatewayProxyEventV2,
 ): Promise<APIGatewayProxyResultV2> => {
+  const context =
+    event.requestContext as APIGatewayEventRequestContextV2WithAuthorizer<APIGatewayEventRequestContextIAMAuthorizer>;
+  console.log('Caller Identity:', context.authorizer.iam.userArn);
   return handlerImpl({ event });
 };
 
@@ -36,7 +40,7 @@ export type Handler = ({
     input: GetInstallationTokenInput,
     _context: { appTable: string; installationTable: string },
   ) => Promise<GetInstallationTokenOutput>;
-}) => Promise<APIGatewayProxyResult>;
+}) => Promise<APIGatewayProxyResultV2>;
 
 /**
  * Core Lambda handler logic for processing GetAppToken requests.

--- a/src/packages/app-framework/test/get-app-token/getAppToken.test.ts
+++ b/src/packages/app-framework/test/get-app-token/getAppToken.test.ts
@@ -140,7 +140,7 @@ describe('getAppTokenImpl', () => {
       validateAppToken: mockValidateAppToken,
     });
     expect(result).toBeTruthy();
-    expect(typeof result).toBe('string');
+    expect(typeof result).toBe('object');
     expect(mockGetArn).toHaveBeenCalledWith({
       appId: mockAppId,
       tableName: mockTableName,

--- a/src/packages/app-framework/test/get-installation-access-token/getInstallationAcessToken.test.ts
+++ b/src/packages/app-framework/test/get-installation-access-token/getInstallationAcessToken.test.ts
@@ -43,6 +43,7 @@ describe('getInstallationAccessTokenImpl', () => {
       appId: 1234,
       nodeId: 'test-id',
       installationToken: 'installation-access-token',
+      expirationTime: new Date('2017-07-08T16:18:44-04:00'),
     });
   });
   it('should throw error when receiving an error generating installation access token', async () => {

--- a/src/packages/app-framework/test/get-installation-access-token/index.handler.test.ts
+++ b/src/packages/app-framework/test/get-installation-access-token/index.handler.test.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayProxyResultV2 } from 'aws-lambda';
 import { InstallationAccessTokenEnvironmentVariables } from '../../src/credential-manager/get-installation-access-token/constants';
 import {
   checkEnvironmentImpl,
@@ -47,13 +47,14 @@ describe('handlerImpl', () => {
     appId: 1234,
   });
   it('should return installation access token with app id and node id', async () => {
-    const response: APIGatewayProxyResult = await handlerImpl({
+    const response: APIGatewayProxyResultV2 = await handlerImpl({
       event: apiGatewayEventHelper({ path, body }),
       getInstallationAccessTokenOperation:
         mockGetInstallationAccessTokenOperation,
       checkEnvironment: mockCheckEnvironment,
     });
-    expect(response.body).toEqual(
+    const parseResponse = JSON.parse(JSON.stringify(response));
+    expect(parseResponse.body).toEqual(
       JSON.stringify({
         appId: 1234,
         installationToken: 'test-token',
@@ -62,21 +63,25 @@ describe('handlerImpl', () => {
     );
   });
   it('should return internal server error for any error occuring inside of operation', async () => {
-    const response: APIGatewayProxyResult = await handlerImpl({
+    const response: APIGatewayProxyResultV2 = await handlerImpl({
       event: apiGatewayEventHelper({ path, body }),
       checkEnvironment: mockCheckEnvironment,
     });
-    expect(response.body).toEqual(
+    const parseResponse = JSON.parse(JSON.stringify(response));
+    expect(parseResponse.body).toEqual(
       JSON.stringify({ message: 'Internal Server Error' }),
     );
   });
   it('should return message for request error', async () => {
-    const badInput = JSON.stringify({ appId: 1234, nodeId: '' });
-    const response: APIGatewayProxyResult = await handlerImpl({
-      event: apiGatewayEventHelper({ path, body: badInput }),
+    const response: APIGatewayProxyResultV2 = await handlerImpl({
+      event: apiGatewayEventHelper({
+        path,
+        body: JSON.stringify({ appId: 1234, nodeId: '' }),
+      }),
       checkEnvironment: mockCheckEnvironment,
     });
-    expect(response.body).toEqual(
+    const parseResponse = JSON.parse(JSON.stringify(response));
+    expect(parseResponse.body).toEqual(
       JSON.stringify({
         fieldList: [
           {

--- a/src/packages/smithy/build/smithy/source/build-info/smithy-build-info.json
+++ b/src/packages/smithy/build/smithy/source/build-info/smithy-build-info.json
@@ -182,6 +182,7 @@
         "smithy.api#recommended",
         "smithy.api#required",
         "smithy.api#tags",
+        "smithy.api#timestampFormat",
         "smithy.api#title",
         "smithy.api#trait",
         "smithy.api#traitValidators",

--- a/src/packages/smithy/build/smithy/source/model/model.json
+++ b/src/packages/smithy/build/smithy/source/model/model.json
@@ -1938,6 +1938,12 @@
                 },
                 "appId": {
                     "target": "smithy.api#Integer"
+                },
+                "expirationTime": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#timestampFormat": "date-time"
+                    }
                 }
             }
         },
@@ -1999,6 +2005,12 @@
                 },
                 "appId": {
                     "target": "smithy.api#Integer"
+                },
+                "expirationTime": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#timestampFormat": "date-time"
+                    }
                 }
             }
         },

--- a/src/packages/smithy/build/smithy/source/sources/credential_management.smithy
+++ b/src/packages/smithy/build/smithy/source/sources/credential_management.smithy
@@ -35,6 +35,8 @@ structure GetInstallationTokenOutput {
     installationToken: String
     nodeId: String
     appId: Integer
+    @timestampFormat("date-time")
+    expirationTime: Timestamp
 }
 
 structure GetAppTokenInput {
@@ -46,6 +48,8 @@ structure GetAppTokenInput {
 structure GetAppTokenOutput {
     appToken: String
     appId: Integer
+    @timestampFormat("date-time")
+    expirationTime: Timestamp
 }
 
 @httpError(500)

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/GetAppTokenCommand.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/GetAppTokenCommand.ts
@@ -52,6 +52,7 @@ export interface GetAppTokenCommandOutput extends GetAppTokenOutput, __MetadataB
  * // { // GetAppTokenOutput
  * //   appToken: "STRING_VALUE",
  * //   appId: Number("int"),
+ * //   expirationTime: new Date("TIMESTAMP"),
  * // };
  *
  * ```

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/GetInstallationTokenCommand.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/GetInstallationTokenCommand.ts
@@ -54,6 +54,7 @@ export interface GetInstallationTokenCommandOutput extends GetInstallationTokenO
  * //   installationToken: "STRING_VALUE",
  * //   nodeId: "STRING_VALUE",
  * //   appId: Number("int"),
+ * //   expirationTime: new Date("TIMESTAMP"),
  * // };
  *
  * ```

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/models/models_0.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/models/models_0.ts
@@ -35,6 +35,7 @@ export interface GetAppTokenInput {
 export interface GetAppTokenOutput {
   appToken?: string | undefined;
   appId?: number | undefined;
+  expirationTime?: Date | undefined;
 }
 
 /**
@@ -119,4 +120,5 @@ export interface GetInstallationTokenOutput {
   installationToken?: string | undefined;
   nodeId?: string | undefined;
   appId?: number | undefined;
+  expirationTime?: Date | undefined;
 }

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/protocols/Aws_restJson1.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/protocols/Aws_restJson1.ts
@@ -30,6 +30,7 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   _json,
   collectBody,
   map,
@@ -104,6 +105,7 @@ export const de_GetAppTokenCommand = async(
   const doc = take(data, {
     'appId': __expectInt32,
     'appToken': __expectString,
+    'expirationTime': _ => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
   });
   Object.assign(contents, doc);
   return contents;
@@ -125,6 +127,7 @@ export const de_GetInstallationTokenCommand = async(
   const data: Record<string, any> = __expectNonNull((__expectObject(await parseBody(output.body, context))), "body");
   const doc = take(data, {
     'appId': __expectInt32,
+    'expirationTime': _ => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
     'installationToken': __expectString,
     'nodeId': __expectString,
   });

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/models/models_0.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/models/models_0.ts
@@ -69,12 +69,14 @@ export namespace GetAppTokenInput {
 export interface GetAppTokenOutput {
   appToken?: string | undefined;
   appId?: number | undefined;
+  expirationTime?: Date | undefined;
 }
 
 export namespace GetAppTokenOutput {
   const memberValidators : {
     appToken?: __MultiConstraintValidator<string>,
     appId?: __MultiConstraintValidator<number>,
+    expirationTime?: __MultiConstraintValidator<Date>,
   } = {};
   /**
    * @internal
@@ -91,6 +93,10 @@ export namespace GetAppTokenOutput {
             memberValidators["appId"] = new __NoOpValidator();
             break;
           }
+          case "expirationTime": {
+            memberValidators["expirationTime"] = new __NoOpValidator();
+            break;
+          }
         }
       }
       return memberValidators[member]!!;
@@ -98,6 +104,7 @@ export namespace GetAppTokenOutput {
     return [
       ...getMemberValidator("appToken").validate(obj.appToken, `${path}/appToken`),
       ...getMemberValidator("appId").validate(obj.appId, `${path}/appId`),
+      ...getMemberValidator("expirationTime").validate(obj.expirationTime, `${path}/expirationTime`),
     ];
   }
 }
@@ -250,6 +257,7 @@ export interface GetInstallationTokenOutput {
   installationToken?: string | undefined;
   nodeId?: string | undefined;
   appId?: number | undefined;
+  expirationTime?: Date | undefined;
 }
 
 export namespace GetInstallationTokenOutput {
@@ -257,6 +265,7 @@ export namespace GetInstallationTokenOutput {
     installationToken?: __MultiConstraintValidator<string>,
     nodeId?: __MultiConstraintValidator<string>,
     appId?: __MultiConstraintValidator<number>,
+    expirationTime?: __MultiConstraintValidator<Date>,
   } = {};
   /**
    * @internal
@@ -277,6 +286,10 @@ export namespace GetInstallationTokenOutput {
             memberValidators["appId"] = new __NoOpValidator();
             break;
           }
+          case "expirationTime": {
+            memberValidators["expirationTime"] = new __NoOpValidator();
+            break;
+          }
         }
       }
       return memberValidators[member]!!;
@@ -285,6 +298,7 @@ export namespace GetInstallationTokenOutput {
       ...getMemberValidator("installationToken").validate(obj.installationToken, `${path}/installationToken`),
       ...getMemberValidator("nodeId").validate(obj.nodeId, `${path}/nodeId`),
       ...getMemberValidator("appId").validate(obj.appId, `${path}/appId`),
+      ...getMemberValidator("expirationTime").validate(obj.expirationTime, `${path}/expirationTime`),
     ];
   }
 }

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/protocols/Aws_restJson1.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/protocols/Aws_restJson1.ts
@@ -36,6 +36,7 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
+  serializeDateTime as __serializeDateTime,
   _json,
   collectBody,
   isSerializableHeaderValue,
@@ -126,6 +127,7 @@ export const serializeGetAppTokenResponse = async(
   body = JSON.stringify(take(input, {
     'appId': [],
     'appToken': [],
+    'expirationTime': _ => __serializeDateTime(_),
   }));
   if (body && Object.keys(headers).map((str) => str.toLowerCase()).indexOf('content-length') === -1) {
     const length = calculateBodyLength(body);
@@ -159,6 +161,7 @@ export const serializeGetInstallationTokenResponse = async(
   let body: any;
   body = JSON.stringify(take(input, {
     'appId': [],
+    'expirationTime': _ => __serializeDateTime(_),
     'installationToken': [],
     'nodeId': [],
   }));

--- a/src/packages/smithy/model/credential_management.smithy
+++ b/src/packages/smithy/model/credential_management.smithy
@@ -35,6 +35,8 @@ structure GetInstallationTokenOutput {
     installationToken: String
     nodeId: String
     appId: Integer
+    @timestampFormat("date-time")
+    expirationTime: Timestamp
 }
 
 structure GetAppTokenInput {
@@ -46,6 +48,8 @@ structure GetAppTokenInput {
 structure GetAppTokenOutput {
     appToken: String
     appId: Integer
+    @timestampFormat("date-time")
+    expirationTime: Timestamp
 }
 
 @httpError(500)


### PR DESCRIPTION
### Notes

I have added in logging for inputs to the APIs, logging SHA-256 hashed tokens for tokens generated by the APIs. I have also added expiration times to API responses in ISO8601 format hence updated the smithy model and the API implementations to fit in the expiration time.

### Testing
The unit tests pass as expected and the expiration time is added in the responses for the APIs in ISO8601 format.