### PR TITLE
chore: Bumping cdk version to 2.189.1

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -109,7 +109,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.184.0",
+      "version": "^2.189.1",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -6,7 +6,7 @@ const projectMetadata = {
   authorAddress: "osa-dev+puzzleglue@amazon.com",
   repositoryUrl:
     "https://github.com/amazon-ospo/framework-for-github-app-on-aws.git",
-  cdkVersion: "2.184.0",
+  cdkVersion: "2.189.1",
   constructsVersion: "10.4.2",
   defaultReleaseBranch: "main",
   name: "framework-for-github-app-on-aws",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^22.13.6",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.184.0",
+    "aws-cdk-lib": "2.189.1",
     "constructs": "10.4.2",
     "eslint": "^9",
     "eslint-config-prettier": "^10.1.1",
@@ -63,7 +63,7 @@
     "typescript": "~5.7.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.184.0",
+    "aws-cdk-lib": "^2.189.1",
     "constructs": "^10.4.2"
   },
   "keywords": [

--- a/src/packages/app-framework/.projen/deps.json
+++ b/src/packages/app-framework/.projen/deps.json
@@ -133,7 +133,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.184.0",
+      "version": "^2.189.1",
       "type": "peer"
     },
     {

--- a/src/packages/app-framework/package.json
+++ b/src/packages/app-framework/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^22.13.9",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.184.0",
+    "aws-cdk-lib": "2.189.1",
     "aws-sdk-client-mock": "^4.1.0",
     "constructs": "10.4.2",
     "eslint": "^9",
@@ -55,7 +55,7 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.184.0",
+    "aws-cdk-lib": "^2.189.1",
     "constructs": "^10.4.2"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-cdk/asset-awscli-v1@^2.2.227", "@aws-cdk/asset-awscli-v1@^2.2.229":
+"@aws-cdk/asset-awscli-v1@^2.2.229":
   version "2.2.233"
   resolved "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.233.tgz#2c5943463b14507d30bbf967b9cf2481848e6eaf"
   integrity sha512-OH5ZN1F/0wwOUwzVUSvE0/syUOi44H9the6IG16anlSptfeQ1fvduJazZAKRuJLtautPbiqxllyOrtWh6LhX8A==
@@ -19,14 +19,6 @@
   version "2.1.0"
   resolved "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
   integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
-
-"@aws-cdk/cloud-assembly-schema@^40.7.0":
-  version "40.7.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz#1d53d55fc616477965338f0de98192ec3a3ed9bc"
-  integrity sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==
-  dependencies:
-    jsonschema "~1.4.1"
-    semver "^7.7.1"
 
 "@aws-cdk/cloud-assembly-schema@^41.0.0":
   version "41.2.0"
@@ -3613,14 +3605,14 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.184.0:
-  version "2.184.0"
-  resolved "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.184.0.tgz#2e1d15bc3e3d0fd270555eb5dba0ad3921dca244"
-  integrity sha512-IC/38376PVCJ9cEsfklH0eBd5uwT7SKZxQJlfAd51TquZ7skpo7dt9oetrkUk4H+tsg4VcTF5B0ZbVZdDDP2yg==
+aws-cdk-lib@2.189.1:
+  version "2.189.1"
+  resolved "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.189.1.tgz#57681865d0ff138a26299066695c06c46329bcb7"
+  integrity sha512-9JU0yUr2iRTJ1oCPrHyx7hOtBDWyUfyOcdb6arlumJnMcQr2cyAMASY8HuAXHc8Y10ipVp8dRTW+J4/132IIYA==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.227"
+    "@aws-cdk/asset-awscli-v1" "^2.2.229"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^40.7.0"
+    "@aws-cdk/cloud-assembly-schema" "^41.0.0"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^11.3.0"


### PR DESCRIPTION
### Notes

Updated CDK version to 2.189.1

### Testing
Deployed CDK constructs and it works as expected.