### PR TITLE
feat: add Acceptance tests for App Token API

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -265,10 +265,22 @@ const theAppFrameworkTestApp = new awscdk.AwsCdkTypeScriptApp({
   parent: project,
   projenrcTs: false,
   cdkVersion: "2.184.1",
+  deps: [
+    "@aws-sdk/hash-node",
+    "@aws/framework-for-github-app-on-aws",
+    "@aws/app-framework-client",
+    "@aws-crypto/sha256-js",
+    "@aws-sdk/credential-provider-node",
+  ],
+  devDeps: ["jest-runner-groups"],
+  jestOptions: {
+    jestConfig: {
+      runner: "groups",
+      verbose: true,
+    },
+  },
 });
 addTestTargets(theAppFrameworkTestApp);
 addPrettierConfig(theAppFrameworkTestApp);
 configureMarkDownLinting(theAppFrameworkTestApp);
-theAppFrameworkTestApp.addDeps("@aws/framework-for-github-app-on-aws");
-theAppFrameworkTestApp.addDeps("@aws-sdk/hash-node");
 project.synth();

--- a/src/packages/app-framework-ops-tools/test/TESTING.md
+++ b/src/packages/app-framework-ops-tools/test/TESTING.md
@@ -32,10 +32,18 @@ accumulate KMS keys.
 
 ## Prerequisites
 
-1. Install a GitHub App and download the private key which is a file in PEM
-   format.
+### Follow Common Setup
 
-1. Keep a track of the file location for the import process
+Refer to the top level [TESTING.md](../../../../test/TESTING.md)
+to set up common prerequisites which include:
+
+- Deploy the infrastructure for Credential Manager
+  to create table resources which will record the appId.
+
+- Install a GitHub App and download the private key which is a file in PEM
+  format.
+
+- Keep a track of the file location for the import process
 
 ## Required AWS Permissions
 
@@ -61,7 +69,7 @@ Ensure AWS credentials have these required permissions:
 1. List available DynamoDB tables:
 
 ```sh
-   npm run get-table-name
+  npm run get-table-name
 ```
 
 1. Set up PEM file path, GitHub App ID,
@@ -70,15 +78,15 @@ Ensure AWS credentials have these required permissions:
 For `DYNAMODB_TABLE_NAME`, select an appropriate table name from `npm run get-table-name`.
 
 ```sh
-export GITHUB_PEM_FILE_PATH=<path-to-your-private-key.pem>
-export GITHUB_APPID=<your-github-app-id>
-export DYNAMODB_TABLE_NAME=<your-dynamo-table-name> # Use the table name you picked from step 1
+  export GITHUB_PEM_FILE_PATH=<path-to-your-private-key.pem>
+  export GITHUB_APPID=<your-github-app-id>
+  export DYNAMODB_TABLE_NAME=<your-dynamo-table-name> # Use the table name you picked from step 1
 ```
 
 1. Execute acceptance tests:
 
 ```sh
-    npm run accept
+  npm run accept
 ```
 
 **Note:** On first run, if the importPrivateKey.ts acceptance tests fail,
@@ -91,7 +99,13 @@ recheck if the environment variables are set correctly.
 
 - To clean up test resources and avoid ongoing costs:
 
-1. Go to your GitHub App settings and delete the generated private keys
+  1. Go to your GitHub App settings and delete the generated private keys
 
-1. Go to AWS KMS console and schedule the KMS keys for deletion with
-   a waiting period between 7 and 30 days
+  1. Go to AWS KMS console and schedule the KMS keys for deletion with
+     a waiting period between 7 and 30 days
+
+  1. Go to AWS console to delete test and nested stack,
+     clean the resources created during the acceptance tests, which include:
+     - Two DynamoDb tables
+     - Three lambda Functions with two lambda Function URLs
+     - One EventBridge scheduler

--- a/src/packages/app-framework-test-app/.projen/deps.json
+++ b/src/packages/app-framework-test-app/.projen/deps.json
@@ -63,6 +63,10 @@
       "type": "build"
     },
     {
+      "name": "jest-runner-groups",
+      "type": "build"
+    },
+    {
       "name": "markdown-eslint-parser",
       "type": "build"
     },
@@ -79,7 +83,19 @@
       "type": "build"
     },
     {
+      "name": "@aws-crypto/sha256-js",
+      "type": "runtime"
+    },
+    {
+      "name": "@aws-sdk/credential-provider-node",
+      "type": "runtime"
+    },
+    {
       "name": "@aws-sdk/hash-node",
+      "type": "runtime"
+    },
+    {
+      "name": "@aws/app-framework-client",
       "type": "runtime"
     },
     {

--- a/src/packages/app-framework-test-app/.projen/tasks.json
+++ b/src/packages/app-framework-test-app/.projen/tasks.json
@@ -190,13 +190,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-md,eslint-plugin-prettier,jest,markdown-eslint-parser,ts-jest,ts-node,typescript,@aws-sdk/hash-node,@aws/framework-for-github-app-on-aws"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-md,eslint-plugin-prettier,jest,jest-runner-groups,markdown-eslint-parser,ts-jest,ts-node,typescript,@aws-crypto/sha256-js,@aws-sdk/credential-provider-node,@aws-sdk/hash-node,@aws/app-framework-client,@aws/framework-for-github-app-on-aws"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @stylistic/eslint-plugin @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-md eslint-plugin-prettier eslint jest jest-junit markdown-eslint-parser ts-jest ts-node typescript @aws-sdk/hash-node @aws/framework-for-github-app-on-aws aws-cdk-lib constructs"
+          "exec": "yarn upgrade @stylistic/eslint-plugin @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-md eslint-plugin-prettier eslint jest jest-junit jest-runner-groups markdown-eslint-parser ts-jest ts-node typescript @aws-crypto/sha256-js @aws-sdk/credential-provider-node @aws-sdk/hash-node @aws/app-framework-client @aws/framework-for-github-app-on-aws aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/src/packages/app-framework-test-app/package.json
+++ b/src/packages/app-framework-test-app/package.json
@@ -37,13 +37,17 @@
     "eslint-plugin-prettier": "^5.2.3",
     "jest": "^29.7.0",
     "jest-junit": "^16",
+    "jest-runner-groups": "^2.2.0",
     "markdown-eslint-parser": "^1.2.1",
     "ts-jest": "^29.2.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2"
   },
   "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
+    "@aws-sdk/credential-provider-node": "^3.806.0",
     "@aws-sdk/hash-node": "^3.374.0",
+    "@aws/app-framework-client": "^0.0.1",
     "@aws/framework-for-github-app-on-aws": "^0.0.0",
     "aws-cdk-lib": "^2.184.1",
     "constructs": "^10.4.2"
@@ -55,6 +59,8 @@
   "version": "0.0.0",
   "jest": {
     "coverageProvider": "v8",
+    "runner": "groups",
+    "verbose": true,
     "testMatch": [
       "<rootDir>/@(src|test)/**/*(*.)@(spec|test).ts?(x)",
       "<rootDir>/@(src|test)/**/__tests__/**/*.ts?(x)"

--- a/src/packages/app-framework-test-app/src/main.ts
+++ b/src/packages/app-framework-test-app/src/main.ts
@@ -1,18 +1,22 @@
-import {
-  CredentialManager,
-  InstallationManager,
-} from '@aws/framework-for-github-app-on-aws';
-import { App, Stack, StackProps } from 'aws-cdk-lib';
+import { CredentialManager } from '@aws/framework-for-github-app-on-aws';
+import { App, Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-
 // CDK App entry for @aws/framework-for-github-app-on-aws acceptance test.
 // This stack is intended for testing @aws/framework-for-github-app-on-aws library.
 // In a real use case, it should be a stack defined by customer.
 export class TheAppFrameworkTestStack extends Stack {
   constructor(scope: Construct, id: string, props: StackProps = {}) {
     super(scope, id, props);
-    new CredentialManager(this, 'CredentialManager', {});
-    new InstallationManager(this, 'InstallationManager', {});
+    const credentialManager = new CredentialManager(
+      this,
+      'CredentialManager',
+      {},
+    );
+    const appTokenUrl = credentialManager.appTokenEndpoint;
+    new CfnOutput(this, 'AppTokenEndpoint', {
+      value: appTokenUrl,
+      exportName: 'AppTokenEndpoint',
+    });
   }
 }
 

--- a/src/packages/app-framework-test-app/test/TESTING.md
+++ b/src/packages/app-framework-test-app/test/TESTING.md
@@ -1,0 +1,114 @@
+# Acceptance Tests for Retrieving GitHub Tokens
+
+This document describes how to run acceptance tests
+for retrieving GitHub App token and Installation access token
+using the deployed Credential Manager infrastructure
+and a private key imported into AWS KMS.
+These tests perform end-to-end validation using real AWS and GitHub resources.
+
+## Overview
+
+This test suite validates:
+
+- Retrieval of a GitHub App token and Installation access token
+  using the deployed Lambda API endpoints.
+
+- Expected behavior for valid and invalid GitHub App IDs.
+
+- Integration across the Framework generated Smithy client,
+  AWS KMS, DynamoDB, and Lambda.
+
+## Required AWS Permissions
+
+Ensure AWS credentials have these additional required permissions:
+
+### **KMS Permissions (Required for Key Management)**
+
+- `kms:CreateKey` - Create new KMS keys
+- `kms:DescribeKey` - Get key metadata and status
+- `kms:GetParametersForImport` - Get import parameters for key material
+- `kms:ImportKeyMaterial` - Import external key material into KMS
+- `kms:ListResourceTags` - List tags associated with KMS keys
+- `kms:TagResource` - Tag keys for tracking status and metadata
+- `kms:Sign` - Generate digital signatures using asymmetric KMS keys
+
+### **DynamoDB Permissions (Required for Table Operations)**
+
+- `dynamodb:PutItem` - Store KMS key ARNs in DynamoDB
+- `dynamodb:GetItem` - Retrieve KMS key ARNs from DynamoDB
+- `dynamodb:ListTables` - List available tables for validation
+
+### **Lambda Permission (Required for invoke Lambda function)**
+
+- `lambda:InvokeFunctionUrl` - Invoke Lambda function URL
+
+## Prerequisites
+
+### 1. Follow Common Setup
+
+Refer to the top level [TESTING.md](../../../../test/TESTING.md)
+to set up common prerequisites.
+
+After that, deploy the Credential Manager infrastructure
+and store the output in `cdk-output.json` file:
+
+```sh
+  npx projen deploy --outputs-file ./cdk-output.json
+```
+
+Make sure the `cdk-output.json` file
+is present at `app-framework-test-app` package
+and includes a valid AppTokenEndpoint value.
+The generated `cdk-output.json` file should include:
+
+```sh
+    {
+      "the-app-framework-test-stack": {
+        "AppTokenEndpoint": <your-lambda-function-url-for-app-token>
+      }
+    }
+```
+
+### 2. Import the PEM file into AWS KMS
+
+These acceptance tests running against real App private Key stored in AWS KMS.
+Please follow [README.md](../../../packages/app-framework-ops-tools/README.md)
+in the `app-framework-ops-tools` package to import your
+app private key to AWS KMS.
+
+### 3. Set Required Environment Variables
+
+Before running the tests, set the required environment variable:
+
+```sh
+    export GITHUB_APPID=<your-github-app-id>
+```
+
+## Running Tests
+
+Execute acceptance tests:
+
+```sh
+    npm run accept
+```
+
+## After Successful test completion
+
+- The PEM file will be automatically deleted from the downloaded location for
+  security.
+
+- To clean up test resources and avoid ongoing costs:
+
+  1. Go to your GitHub App settings and delete the generated private keys
+
+  1. Go to AWS KMS console and schedule the KMS keys for deletion with
+     a waiting period between 7 and 30 days
+
+  1. Go to AWS console to delete test and nested stack,
+     clean the resources created during the acceptance tests, which include:
+
+     - Two DynamoDb tables
+     - Three lambda Functions with two lambda Function URLs
+     - One EventBridge scheduler
+
+  1. Delete your local `cdk-output.json` file.

--- a/src/packages/app-framework-test-app/test/getAppToken.accept.test.ts
+++ b/src/packages/app-framework-test-app/test/getAppToken.accept.test.ts
@@ -1,0 +1,105 @@
+import * as fs from 'fs';
+import {
+  AppFrameworkClient,
+  GetAppTokenCommand,
+} from '@aws/app-framework-client';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+/**
+ @group accept
+ */
+describe('Smithy client for app token API', () => {
+  let endpoint: string;
+  let region: string;
+  const validAppId = Number(process.env.GITHUB_APPID);
+  beforeAll(() => {
+    const outputPath = './cdk-output.json';
+    if (!fs.existsSync(outputPath)) {
+      throw new Error(`
+            Can not find cdk-output.json file. 
+            To run acceptance tests, 
+            please get the App Token endpoint from deployed Credential Manager Component:
+      
+            Run 'npx projen deploy --outputs-file ./cdk-output.json'
+      
+            Then run the tests again with:
+            npm run accept
+      `);
+    }
+    const output = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    endpoint = output['the-app-framework-test-stack'].AppTokenEndpoint;
+    region = 'us-west-2';
+    if (!endpoint) {
+      throw new Error(
+        `Invalid or missing endpoint in cdk-output.json: ${JSON.stringify(endpoint)}`,
+      );
+    }
+    if (!validAppId) {
+      throw new Error(`
+            Missing required environment variables.
+            To run acceptance tests, please set the following environment variables:
+            
+            export GITHUB_APPID=<your-github-app-id>
+
+            Current values:
+            APPID: ${validAppId ? validAppId : 'NOT_SET'}
+
+            Then run the tests again with:
+            npm run accept
+        `);
+    }
+  });
+  it('should return a valid app token for a valid appId', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    const command = new GetAppTokenCommand({ appId: validAppId });
+    const response = await client.send(command);
+    expect(response).toHaveProperty('appId');
+    expect(typeof response.appId).toBe('number');
+    expect(response).toHaveProperty('appToken');
+    expect(typeof response.appToken).toBe('string');
+    expect(response).toHaveProperty('expirationTime');
+  });
+  it('should return a validation error for appId=0', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    await expect(
+      client.send(new GetAppTokenCommand({ appId: 0 })),
+    ).rejects.toThrow(
+      "1 validation error detected. Value at '/appId' failed to satisfy constraint: Member must be greater than or equal to 1",
+    );
+  });
+  it('should return a not found error for a non-existent appId', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    const command = new GetAppTokenCommand({ appId: 9999999 });
+    await expect(client.send(command)).rejects.toThrow(
+      'Invalid Request: Error: Item not found',
+    );
+  });
+  it('should fail if credentials are missing', async () => {
+    const missingCredentialsProvider = async () => {
+      throw new Error('Missing credentials');
+    };
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: missingCredentialsProvider,
+      sha256: Sha256,
+    });
+    const command = new GetAppTokenCommand({ appId: 1161167 });
+    await expect(client.send(command)).rejects.toThrow('Missing credentials');
+  });
+});

--- a/src/packages/smithy/build/smithy/source/model/model.json
+++ b/src/packages/smithy/build/smithy/source/model/model.json
@@ -1861,7 +1861,7 @@
             ],
             "traits": {
                 "aws.auth#sigv4": {
-                    "name": "execute-api"
+                    "name": "lambda"
                 },
                 "aws.protocols#restJson1": {},
                 "smithy.api#auth": [

--- a/src/packages/smithy/build/smithy/source/sources/main.smithy
+++ b/src/packages/smithy/build/smithy/source/sources/main.smithy
@@ -8,7 +8,7 @@ use smithy.framework#ValidationException
 
 @title("Framework for GitHub Apps on AWS")
 @auth([sigv4])
-@sigv4(name: "execute-api")
+@sigv4(name: "lambda")
 @restJson1
 service AppFramework {
     version: "2024-08-23"

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/auth/httpAuthSchemeProvider.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/auth/httpAuthSchemeProvider.ts
@@ -50,7 +50,7 @@ function createAwsAuthSigv4HttpAuthOption(authParameters: AppFrameworkHttpAuthSc
   return {
     schemeId: "aws.auth#sigv4",
     signingProperties: {
-      name: "execute-api",
+      name: "lambda",
       region: authParameters.region,
     },
     propertiesExtractor: (config, context) => {

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/index.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/index.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // smithy-typescript generated code
 export * from "./GetAppTokenCommand";
 export * from "./GetInstallationTokenCommand";

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/extensionConfiguration.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/extensionConfiguration.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // smithy-typescript generated code
 import { HttpAuthExtensionConfiguration } from "./auth/httpAuthExtensionConfiguration";
 import { AwsRegionExtensionConfiguration } from "@aws-sdk/types";

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/index.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // smithy-typescript generated code
 /* eslint-disable */
 export * from "./AppFrameworkClient";

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/runtimeConfig.shared.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/runtimeConfig.shared.ts
@@ -33,7 +33,7 @@ export const getRuntimeConfig = (config: AppFrameworkClientConfig) => {
         signer: new SigV4Signer(),
       }],
   logger: config?.logger ?? new NoOpLogger(),
-  signingName: config?.signingName ?? "execute-api",
+  signingName: config?.signingName ?? "lambda",
   urlParser: config?.urlParser ?? parseUrl,
   utf8Decoder: config?.utf8Decoder ?? fromUtf8,
   utf8Encoder: config?.utf8Encoder ?? toUtf8,

--- a/src/packages/smithy/model/main.smithy
+++ b/src/packages/smithy/model/main.smithy
@@ -8,7 +8,7 @@ use smithy.framework#ValidationException
 
 @title("Framework for GitHub Apps on AWS")
 @auth([sigv4])
-@sigv4(name: "execute-api")
+@sigv4(name: "lambda")
 @restJson1
 service AppFramework {
     version: "2024-08-23"

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -1,0 +1,64 @@
+# Acceptance Tests
+
+This document outlines the common prerequisites for
+running acceptance tests across the packages in this repository.
+There are acceptance tests in:
+
+[app-framework-ops-tool](../src/packages/app-framework-ops-tools/test/TESTING.md):
+for importing GitHub App's private key into AWS KMS
+
+[app-framework-test-app](../src/packages/app-framework-test-app/test/TESTING.md):
+for retrieving GitHub App token and Installation token
+
+This document helps you set up shared prerequisites.
+Please also refer to each package’s `TESTING.md` for specific instructions.
+
+## Overview
+
+The `framework-for-github-app-on-aws` Credential Manager is an L3 CDK construct
+that provisions infrastructure in your AWS account.
+
+To run acceptance tests, you must:
+
+1. Deploy the infrastructure
+1. Download the GitHub Private Key from GitHub website to your local
+
+Credential Manager APIs use these setup to import GitHub App private key
+to AWS KMS and generate GitHub tokens securely.
+
+**IMPORTANT:** This process interacts with live AWS services and will:
+
+- Create AWS resources (incurs costs)
+- Create KMS keys
+- Store data in DynamoDB
+- Make calls to GitHub’s API
+- Perform cryptographic operations
+- Run a scheduler job to sync GitHub App installations.
+
+Monitor your AWS usage and billing carefully.
+Repeated test runs may accumulate inactive KMS keys.
+
+## Prerequisites
+
+1. Deploy Credential Manager instance in your AWS account:
+
+   At the top level directory of `app-framework-test-app` package, run
+
+   ```sh
+     npx projen depoy
+   ```
+
+   Which will deploy testing stack
+   `the-app-framework-test-stack` in your AWS account.
+   It will also create a Nested stack with the name begin with
+   `the-app-framework-test-stack-CredentialManagerNestedStack`.
+   Under this stack, it will create:
+
+   - Two DynamoDb table
+   - Three lambda Function with two lambda Function URL
+   - One EventBridge Scheduler
+
+1. Go to GitHub, install a GitHub App and download the private key
+   which is a file in PEM format.
+
+1. Keep a track of the file location for the import process.

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,6 +293,50 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/client-sso@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.806.0.tgz#fc09e505d41eaca3f3199bcae537caed1221528a"
+  integrity sha512-X0p/9/u9e6b22rlQqKucdtjdqmjSNB4c/8zDEoD5MvgYAAbMF9HNE0ST2xaA/WsJ7uE0jFfhPY2/00pslL1DqQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/middleware-host-header" "3.804.0"
+    "@aws-sdk/middleware-logger" "3.804.0"
+    "@aws-sdk/middleware-recursion-detection" "3.804.0"
+    "@aws-sdk/middleware-user-agent" "3.806.0"
+    "@aws-sdk/region-config-resolver" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@aws-sdk/util-endpoints" "3.806.0"
+    "@aws-sdk/util-user-agent-browser" "3.804.0"
+    "@aws-sdk/util-user-agent-node" "3.806.0"
+    "@smithy/config-resolver" "^4.1.1"
+    "@smithy/core" "^3.3.1"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/hash-node" "^4.0.2"
+    "@smithy/invalid-dependency" "^4.0.2"
+    "@smithy/middleware-content-length" "^4.0.2"
+    "@smithy/middleware-endpoint" "^4.1.3"
+    "@smithy/middleware-retry" "^4.1.4"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.3"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.11"
+    "@smithy/util-defaults-mode-node" "^4.0.11"
+    "@smithy/util-endpoints" "^3.0.3"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.3"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/core@3.775.0":
   version "3.775.0"
   resolved "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz#5d22ba78f07c07b48fb4d5b18172b9a896c0cbd0"
@@ -327,6 +371,23 @@
     fast-xml-parser "4.4.1"
     tslib "^2.6.2"
 
+"@aws-sdk/core@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.806.0.tgz#e8e8464238b5070b7fa0a0df7351aa1bcd0540b2"
+  integrity sha512-HJRINPncdjPK0iL3f6cBpqCMaxVwq2oDbRCzOx04tsLZ0tNgRACBfT3d/zNVRvMt6fnOVKXoN1LAtQaw50pjEA==
+  dependencies:
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/core" "^3.3.1"
+    "@smithy/node-config-provider" "^4.1.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/signature-v4" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.3"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-middleware" "^4.0.2"
+    fast-xml-parser "4.4.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-env@3.775.0":
   version "3.775.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz#b8c81818f4c62d89b5f04dc410ab9b48e954f22c"
@@ -345,6 +406,17 @@
   dependencies:
     "@aws-sdk/core" "3.798.0"
     "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.806.0.tgz#e480de3a5340d0297ff96a4612f3c913e24994c0"
+  integrity sha512-nbPwmZn0kt6Q1XI2FaJWP6AhF9tro4cO5HlmZQx8NU+B0H1y9WMo659Q5zLLY46BXgoQVIJEsPSZpcZk27O4aw==
+  dependencies:
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
@@ -377,6 +449,22 @@
     "@smithy/property-provider" "^4.0.2"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/smithy-client" "^4.2.1"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-stream" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.806.0.tgz#17cdea3fb73062f14aec1aadba1b66c717578253"
+  integrity sha512-e/gB2iJQQ4ZpecOVpEFhEvjGwuTqNCzhVaVsFYVc49FPfR1seuN7qBGYe1MO7mouGDQFInzJgcNup0DnYUrLiw==
+  dependencies:
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.3"
     "@smithy/types" "^4.2.0"
     "@smithy/util-stream" "^4.2.0"
     tslib "^2.6.2"
@@ -419,6 +507,25 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-ini@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.806.0.tgz#535cef9b760089e02811030202b69f6d54973ad4"
+  integrity sha512-FogfbuYSEZgFxbNy0QcsBZHHe5mSv5HV3+JyB5n0kCyjOISCVCZD7gwxKdXjt8O1hXq5k5SOdQvydGULlB6rew==
+  dependencies:
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/credential-provider-env" "3.806.0"
+    "@aws-sdk/credential-provider-http" "3.806.0"
+    "@aws-sdk/credential-provider-process" "3.806.0"
+    "@aws-sdk/credential-provider-sso" "3.806.0"
+    "@aws-sdk/credential-provider-web-identity" "3.806.0"
+    "@aws-sdk/nested-clients" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/credential-provider-imds" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-node@3.787.0":
   version "3.787.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.787.0.tgz#3e5cdafb0fecca25b7430f848cbca85000b25c33"
@@ -455,6 +562,24 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-node@^3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.806.0.tgz#7bda185597d31beed9331aef95b00068fb3e1a39"
+  integrity sha512-fZX8xP2Kf0k70kDTog/87fh/M+CV0E2yujSw1cUBJhDSwDX3RlUahiJk7TpB/KGw6hEFESMd6+7kq3UzYuw3rg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.806.0"
+    "@aws-sdk/credential-provider-http" "3.806.0"
+    "@aws-sdk/credential-provider-ini" "3.806.0"
+    "@aws-sdk/credential-provider-process" "3.806.0"
+    "@aws-sdk/credential-provider-sso" "3.806.0"
+    "@aws-sdk/credential-provider-web-identity" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/credential-provider-imds" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-process@3.775.0":
   version "3.775.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz#7ab90383f12461c5d20546e933924e654660542b"
@@ -474,6 +599,18 @@
   dependencies:
     "@aws-sdk/core" "3.798.0"
     "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.806.0.tgz#5b26539982b6f1d29ae072194ba973adae4c25a3"
+  integrity sha512-8Y8GYEw/1e5IZRDQL02H6nsTDcRWid/afRMeWg+93oLQmbHcTtdm48tjis+7Xwqy+XazhMDmkbUht11QPTDJcQ==
+  dependencies:
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/shared-ini-file-loader" "^4.0.2"
     "@smithy/types" "^4.2.0"
@@ -507,6 +644,20 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-sso@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.806.0.tgz#2d241d5e6179b4f60bc06018d9de3db9bd8ef64a"
+  integrity sha512-hT9OBwCxWMPBydNhXm2gdNNzx5AJNheS9RglwDDvXWzQ9qDuRztjuMBilMSUMb0HF9K4IqQjYzGqczMuktz4qQ==
+  dependencies:
+    "@aws-sdk/client-sso" "3.806.0"
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/token-providers" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-web-identity@3.787.0":
   version "3.787.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.787.0.tgz#d492d1f4a90b70f3a71a65f11b8d3ef79fb2759e"
@@ -527,6 +678,18 @@
     "@aws-sdk/core" "3.798.0"
     "@aws-sdk/nested-clients" "3.798.0"
     "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.806.0.tgz#8c656f39d93a33b6efa63c52b368f691bcb6e66b"
+  integrity sha512-XxaSY9Zd3D4ClUGENYMvi52ac5FuJPPAsvRtEfyrSdEpf6QufbMpnexWBZMYRF31h/VutgqtJwosGgNytpxMEg==
+  dependencies:
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/nested-clients" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
@@ -569,6 +732,16 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-host-header@3.804.0":
+  version "3.804.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.804.0.tgz#e4c2180cfc75f19c697974383324509fa104d7a3"
+  integrity sha512-bum1hLVBrn2lJCi423Z2fMUYtsbkGI2s4N+2RI2WSjvbaVyMSv/WcejIrjkqiiMR+2Y7m5exgoKeg4/TODLDPQ==
+  dependencies:
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-logger@3.775.0":
   version "3.775.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz#df1909d441cd4bade8d6c7d24c41532808db0e81"
@@ -578,12 +751,31 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-logger@3.804.0":
+  version "3.804.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.804.0.tgz#9b7860d0193ec8647a1102aa6ffad070e3260513"
+  integrity sha512-w/qLwL3iq0KOPQNat0Kb7sKndl9BtceigINwBU7SpkYWX9L/Lem6f8NPEKrC9Tl4wDBht3Yztub4oRTy/horJA==
+  dependencies:
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-recursion-detection@3.775.0":
   version "3.775.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz#36a40f467754d7c86424d12ef45c05e96ce3475b"
   integrity sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==
   dependencies:
     "@aws-sdk/types" "3.775.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@3.804.0":
+  version "3.804.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.804.0.tgz#797bbe72c765e83a1d4c259db9799b77831e1fbb"
+  integrity sha512-zqHOrvLRdsUdN/ehYfZ9Tf8svhbiLLz5VaWUz22YndFv6m9qaAcijkpAOlKexsv3nLBMJdSdJ6GUTAeIy3BZzw==
+  dependencies:
+    "@aws-sdk/types" "3.804.0"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
@@ -610,6 +802,19 @@
     "@aws-sdk/types" "3.775.0"
     "@aws-sdk/util-endpoints" "3.787.0"
     "@smithy/core" "^3.3.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-user-agent@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.806.0.tgz#a0777ed71b1d41a77d5d3f425e55682a763de91b"
+  integrity sha512-XoIromVffgXnc+/mjlR2EVzQVIei3bPVtafIZNsHuEmUvIWJXiWsa2eJpt3BUqa0HF9YPknK7ommNEhqRb8ucg==
+  dependencies:
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@aws-sdk/util-endpoints" "3.806.0"
+    "@smithy/core" "^3.3.1"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
@@ -702,6 +907,50 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/nested-clients@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.806.0.tgz#701ff67a713fd202eeffe3ecba0844bb23a2e22e"
+  integrity sha512-ua2gzpfQ9MF8Rny+tOAivowOWWvqEusez2rdcQK8jdBjA1ANd/0xzToSZjZh0ziN8Kl8jOhNnHbQJ0v6dT6+hg==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/middleware-host-header" "3.804.0"
+    "@aws-sdk/middleware-logger" "3.804.0"
+    "@aws-sdk/middleware-recursion-detection" "3.804.0"
+    "@aws-sdk/middleware-user-agent" "3.806.0"
+    "@aws-sdk/region-config-resolver" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@aws-sdk/util-endpoints" "3.806.0"
+    "@aws-sdk/util-user-agent-browser" "3.804.0"
+    "@aws-sdk/util-user-agent-node" "3.806.0"
+    "@smithy/config-resolver" "^4.1.1"
+    "@smithy/core" "^3.3.1"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/hash-node" "^4.0.2"
+    "@smithy/invalid-dependency" "^4.0.2"
+    "@smithy/middleware-content-length" "^4.0.2"
+    "@smithy/middleware-endpoint" "^4.1.3"
+    "@smithy/middleware-retry" "^4.1.4"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.3"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.11"
+    "@smithy/util-defaults-mode-node" "^4.0.11"
+    "@smithy/util-endpoints" "^3.0.3"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.3"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/protocol-http@^3.267.0":
   version "3.374.0"
   resolved "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.374.0.tgz#e35e76096b995bbed803897a9f4587d11ca34088"
@@ -717,6 +966,18 @@
   dependencies:
     "@aws-sdk/types" "3.775.0"
     "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-config-provider" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.806.0.tgz#dd0240cff0f96f3e4229585bf533800091d4f802"
+  integrity sha512-cuv5pX55JOlzKC/iLsB5nZ9eUyVgncim3VhhWHZA/KYPh7rLMjOEfZ+xyaE9uLJXGmzOJboFH7+YdTRdIcOgrg==
+  dependencies:
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/types" "^4.2.0"
     "@smithy/util-config-provider" "^4.0.0"
     "@smithy/util-middleware" "^4.0.2"
@@ -746,10 +1007,30 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/token-providers@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.806.0.tgz#e67e9488902c3888b2b2e23f1f93d88ad348a12f"
+  integrity sha512-I6SxcsvV7yinJZmPgGullFHS0tsTKa7K3jEc5dmyCz8X+kZPfsWNffZmtmnCvWXPqMXWBvK6hVaxwomx79yeHA==
+  dependencies:
+    "@aws-sdk/nested-clients" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/types@3.775.0", "@aws-sdk/types@^3.222.0", "@aws-sdk/types@^3.267.0", "@aws-sdk/types@^3.4.1":
   version "3.775.0"
   resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz#09863a9e68c080947db7c3d226d1c56b8f0f5150"
   integrity sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@3.804.0":
+  version "3.804.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.804.0.tgz#b70a734fa721450cf8a513cec0c276001a5d154f"
+  integrity sha512-A9qnsy9zQ8G89vrPPlNG9d1d8QcKRGqJKqwyGgS0dclJpwy6d1EWgQLIolKPl6vcFpLoe6avLOLxr+h8ur5wpg==
   dependencies:
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
@@ -771,6 +1052,16 @@
     "@smithy/util-endpoints" "^3.0.2"
     tslib "^2.6.2"
 
+"@aws-sdk/util-endpoints@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.806.0.tgz#bb45ce9a5e10e84014d9114829185752547b98ad"
+  integrity sha512-3YRRgZ+qFuWDdm5uAbxKsr65UAil4KkrFKua9f4m7Be3v24ETiFOOqhanFUIk9/WOtvzF7oFEiDjYKDGlwV2xg==
+  dependencies:
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-endpoints" "^3.0.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/util-locate-window@^3.0.0":
   version "3.723.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz#174551bfdd2eb36d3c16e7023fd7e7ee96ad0fa9"
@@ -784,6 +1075,16 @@
   integrity sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==
   dependencies:
     "@aws-sdk/types" "3.775.0"
+    "@smithy/types" "^4.2.0"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-browser@3.804.0":
+  version "3.804.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.804.0.tgz#0312fda0fd34958a1d89e7691c5b1cf41ad5549b"
+  integrity sha512-KfW6T6nQHHM/vZBBdGn6fMyG/MgX5lq82TDdX4HRQRRuHKLgBWGpKXqqvBwqIaCdXwWHgDrg2VQups6GqOWW2A==
+  dependencies:
+    "@aws-sdk/types" "3.804.0"
     "@smithy/types" "^4.2.0"
     bowser "^2.11.0"
     tslib "^2.6.2"
@@ -807,6 +1108,17 @@
     "@aws-sdk/middleware-user-agent" "3.798.0"
     "@aws-sdk/types" "3.775.0"
     "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.806.0.tgz#a34cd1d72f5ea164c90dcf69008ee4f19449a8a6"
+  integrity sha512-Az2e4/gmPZ4BpB7QRj7U76I+fctXhNcxlcgsaHnMhvt+R30nvzM2EhsyBUvsWl8+r9bnLeYt9BpvEZeq2ANDzA==
+  dependencies:
+    "@aws-sdk/middleware-user-agent" "3.806.0"
+    "@aws-sdk/types" "3.804.0"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
@@ -2004,7 +2316,7 @@
 
 "@octokit/auth-token@^5.0.0":
   version "5.1.2"
-  resolved "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz#68a486714d7a7fd1df56cb9bc89a860a0de866de"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-5.1.2.tgz#68a486714d7a7fd1df56cb9bc89a860a0de866de"
   integrity sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==
 
 "@octokit/core@^5.0.2":
@@ -2022,7 +2334,7 @@
 
 "@octokit/core@^6.1.4":
   version "6.1.5"
-  resolved "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz#c2842aae87c2c2130b7dd33e8caa0f642dde2c67"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-6.1.5.tgz#c2842aae87c2c2130b7dd33e8caa0f642dde2c67"
   integrity sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==
   dependencies:
     "@octokit/auth-token" "^5.0.0"
@@ -2035,7 +2347,7 @@
 
 "@octokit/endpoint@^10.1.4":
   version "10.1.4"
-  resolved "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz#8783be38a32b95af8bcb6523af20ab4eed7a2adb"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-10.1.4.tgz#8783be38a32b95af8bcb6523af20ab4eed7a2adb"
   integrity sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==
   dependencies:
     "@octokit/types" "^14.0.0"
@@ -2060,7 +2372,7 @@
 
 "@octokit/graphql@^8.2.2":
   version "8.2.2"
-  resolved "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz#3db48c4ffdf07f99600cee513baf45e73eced4d1"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-8.2.2.tgz#3db48c4ffdf07f99600cee513baf45e73eced4d1"
   integrity sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==
   dependencies:
     "@octokit/request" "^9.2.3"
@@ -2074,7 +2386,7 @@
 
 "@octokit/openapi-types@^25.0.0":
   version "25.0.0"
-  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.0.0.tgz#adeead36992abf966e89dcd53518d8b0dc910e0d"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-25.0.0.tgz#adeead36992abf966e89dcd53518d8b0dc910e0d"
   integrity sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==
 
 "@octokit/plugin-enterprise-rest@6.0.1":
@@ -2091,7 +2403,7 @@
 
 "@octokit/plugin-paginate-rest@^11.4.2":
   version "11.6.0"
-  resolved "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz#e5e9ff3530e867c3837fdbff94ce15a2468a1f37"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz#e5e9ff3530e867c3837fdbff94ce15a2468a1f37"
   integrity sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==
   dependencies:
     "@octokit/types" "^13.10.0"
@@ -2103,7 +2415,7 @@
 
 "@octokit/plugin-request-log@^5.3.1":
   version "5.3.1"
-  resolved "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz#ccb75d9705de769b2aa82bcd105cc96eb0c00f69"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz#ccb75d9705de769b2aa82bcd105cc96eb0c00f69"
   integrity sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==
 
 "@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1":
@@ -2115,7 +2427,7 @@
 
 "@octokit/plugin-rest-endpoint-methods@^13.3.0":
   version "13.5.0"
-  resolved "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz#d8c8ca2123b305596c959a9134dfa8b0495b0ba6"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz#d8c8ca2123b305596c959a9134dfa8b0495b0ba6"
   integrity sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==
   dependencies:
     "@octokit/types" "^13.10.0"
@@ -2131,7 +2443,7 @@
 
 "@octokit/request-error@^6.1.8":
   version "6.1.8"
-  resolved "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz#3c7ce1ca6721eabd43dbddc76b44860de1fdea75"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-6.1.8.tgz#3c7ce1ca6721eabd43dbddc76b44860de1fdea75"
   integrity sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==
   dependencies:
     "@octokit/types" "^14.0.0"
@@ -2148,7 +2460,7 @@
 
 "@octokit/request@^9.2.3":
   version "9.2.3"
-  resolved "https://registry.npmjs.org/@octokit/request/-/request-9.2.3.tgz#00d023ad690903d952e4dd31e3f5804ef98fcd24"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-9.2.3.tgz#00d023ad690903d952e4dd31e3f5804ef98fcd24"
   integrity sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==
   dependencies:
     "@octokit/endpoint" "^10.1.4"
@@ -2169,7 +2481,7 @@
 
 "@octokit/rest@^21.1.1":
   version "21.1.1"
-  resolved "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz#7a70455ca451b1d253e5b706f35178ceefb74de2"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-21.1.1.tgz#7a70455ca451b1d253e5b706f35178ceefb74de2"
   integrity sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==
   dependencies:
     "@octokit/core" "^6.1.4"
@@ -2186,7 +2498,7 @@
 
 "@octokit/types@^14.0.0":
   version "14.0.0"
-  resolved "https://registry.npmjs.org/@octokit/types/-/types-14.0.0.tgz#bbd1d31e2269940789ef143b1c37918aae09adc4"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-14.0.0.tgz#bbd1d31e2269940789ef143b1c37918aae09adc4"
   integrity sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==
   dependencies:
     "@octokit/openapi-types" "^25.0.0"
@@ -2347,10 +2659,35 @@
     "@smithy/util-middleware" "^4.0.2"
     tslib "^2.6.2"
 
+"@smithy/config-resolver@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.1.1.tgz#12f6da81551a99d447da47050501562b2646b779"
+  integrity sha512-FZUtpiDnPZQmuIl4lfbdO+u3foNLmRCKct/2w2nRwgB99Yvaq4SHcfxyzMfxkyBrBmgnF1kdXzhHNXN7ycDvWg==
+  dependencies:
+    "@smithy/node-config-provider" "^4.1.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-config-provider" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.2"
+    tslib "^2.6.2"
+
 "@smithy/core@^3.2.0", "@smithy/core@^3.3.0":
   version "3.3.0"
   resolved "https://registry.npmjs.org/@smithy/core/-/core-3.3.0.tgz#a6b141733fa530cb2f9b49a8e70ae98169c92cf0"
   integrity sha512-r6gvs5OfRq/w+9unPm7B3po4rmWaGh0CIL/OwHntGGux7+RhOOZLGuurbeMgWV6W55ZuyMTypJLeH0vn/ZRaWQ==
+  dependencies:
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-stream" "^4.2.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/core@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.3.1.tgz#6119a683f62099158eb193e3745f4ade6de741dd"
+  integrity sha512-W7AppgQD3fP1aBmo8wWo0id5zeR2/aYRy067vZsDVaa6v/mdhkg6DxXwEVuSPjZl+ZnvWAQbUMCd5ckw38+tHQ==
   dependencies:
     "@smithy/middleware-serde" "^4.0.3"
     "@smithy/protocol-http" "^5.1.0"
@@ -2367,6 +2704,17 @@
   integrity sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==
   dependencies:
     "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.3.tgz#574640e889705a2fc5b62356277da1df336e4bbc"
+  integrity sha512-UdNvGjZnunS9+45gHYtVXDynoWH1X0tYY0pS368k1zUZum6Mm4ivU4Se0WhFJf8jNocD+p94khzTtrx4ha3OOQ==
+  dependencies:
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
     "@smithy/url-parser" "^4.0.2"
@@ -2469,6 +2817,20 @@
     "@smithy/util-middleware" "^4.0.2"
     tslib "^2.6.2"
 
+"@smithy/middleware-endpoint@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.3.tgz#a972033a772904a1138e03e0cda35eccde3a5045"
+  integrity sha512-w7fJjCSqdTVTs1o1O7SRZm+Umf6r/FzkdlO5OH6tboASeUeugnMgQAs7gnc2dXvJVJtEGrmrBgPZFPxq3wWyzw==
+  dependencies:
+    "@smithy/core" "^3.3.1"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/node-config-provider" "^4.1.0"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    tslib "^2.6.2"
+
 "@smithy/middleware-retry@^4.1.0", "@smithy/middleware-retry@^4.1.1":
   version "4.1.1"
   resolved "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.1.tgz#8c65dec6fca1f4883a10f724f9d6cafea19d0ba4"
@@ -2481,6 +2843,21 @@
     "@smithy/types" "^4.2.0"
     "@smithy/util-middleware" "^4.0.2"
     "@smithy/util-retry" "^4.0.2"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
+"@smithy/middleware-retry@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.4.tgz#060b24caebcefd771f3c2fa8eb6078aa06aa41e0"
+  integrity sha512-QtWuD7bd7AAEFKvBmLQdOax25bXv4BACLQNWi3ddvpWwUUSAkAku9mzI+28jbjg48qw28lbzJ+YoYbbaXhLUjw==
+  dependencies:
+    "@smithy/node-config-provider" "^4.1.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/service-error-classification" "^4.0.3"
+    "@smithy/smithy-client" "^4.2.3"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.3"
     tslib "^2.6.2"
     uuid "^9.0.1"
 
@@ -2504,6 +2881,16 @@
   version "4.0.2"
   resolved "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz#017ba626828bced0fa588e795246e5468632f3ef"
   integrity sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==
+  dependencies:
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/node-config-provider@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-4.1.0.tgz#5ae4e02e4bc0bf95220fb17029c42e41cb8bdfb1"
+  integrity sha512-gmPsv6L3ZRlBinv+vtSGUwfhTMh4+SgjbgGdX7bqYEs3Ys5RYVQtLuZ/WgZZdxn8QrDSUqLmTWunLM96WyM7UQ==
   dependencies:
     "@smithy/property-provider" "^4.0.2"
     "@smithy/shared-ini-file-loader" "^4.0.2"
@@ -2576,6 +2963,13 @@
   dependencies:
     "@smithy/types" "^4.2.0"
 
+"@smithy/service-error-classification@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-4.0.3.tgz#df43e3ec00a9f2d15415185561d98cd602c8bc67"
+  integrity sha512-FTbcajmltovWMjj3tksDQdD23b2w6gH+A0DYA1Yz3iSpjDj8fmkwy62UnXcWMy4d5YoMoSyLFHMfkEVEzbiN8Q==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+
 "@smithy/shared-ini-file-loader@^4.0.2":
   version "4.0.2"
   resolved "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz#15043f0516fe09ff4b22982bc5f644dc701ebae5"
@@ -2605,6 +2999,19 @@
   dependencies:
     "@smithy/core" "^3.3.0"
     "@smithy/middleware-endpoint" "^4.1.1"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-stream" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/smithy-client@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.2.3.tgz#f7cd92c4ccfd7834c50027e0a86513d9012d5f2b"
+  integrity sha512-j/RRx6N007rJQ3qyjN4yuX9B0bxTn9ynDVxYQ43mcs7fluVJXmQGquy0TrWJfOPZcIikpY377GunZ2UK90GHYQ==
+  dependencies:
+    "@smithy/core" "^3.3.1"
+    "@smithy/middleware-endpoint" "^4.1.3"
     "@smithy/middleware-stack" "^4.0.2"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/types" "^4.2.0"
@@ -2695,6 +3102,17 @@
   dependencies:
     tslib "^2.6.2"
 
+"@smithy/util-defaults-mode-browser@^4.0.11":
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.11.tgz#1f3901078a5ab7ac883f16d0114d7991a4fdc6ee"
+  integrity sha512-Z49QNUSKbEj7JVZqaSUZkTkexRciQBbmonJ8AMar4fA0S2kvVpgjeVyGXnZYWTFzkgEwStacjFq4cQKbaQ8AnQ==
+  dependencies:
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/smithy-client" "^4.2.3"
+    "@smithy/types" "^4.2.0"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
 "@smithy/util-defaults-mode-browser@^4.0.8", "@smithy/util-defaults-mode-browser@^4.0.9":
   version "4.0.9"
   resolved "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.9.tgz#b70915229126eee4c1df18cd8f1e8edabade9c41"
@@ -2704,6 +3122,19 @@
     "@smithy/smithy-client" "^4.2.1"
     "@smithy/types" "^4.2.0"
     bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-node@^4.0.11":
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.11.tgz#8dccc28ac46f008cc54726bb7413dbfa8dcf8490"
+  integrity sha512-y9UYcXjz4ry5sDPX40Vy6224Cw2/dch+wET6giaRoeXpyh56DCUVxW+Mgc/gO2uczAKktWd4ZWs2LWcW+PHz3Q==
+  dependencies:
+    "@smithy/config-resolver" "^4.1.1"
+    "@smithy/credential-provider-imds" "^4.0.3"
+    "@smithy/node-config-provider" "^4.1.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/smithy-client" "^4.2.3"
+    "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
 "@smithy/util-defaults-mode-node@^4.0.8", "@smithy/util-defaults-mode-node@^4.0.9":
@@ -2728,6 +3159,15 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@smithy/util-endpoints@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-3.0.3.tgz#efcb535e92a9825e4cd8220adccff75433100ebb"
+  integrity sha512-284PZFhCMdudqq61/E67zJ3i10gCYrMBjXcMg3h048qI39gTXQCCeNZvtJhL4vrj9yMpJ/y9M+Ek7V0o5tak3w==
+  dependencies:
+    "@smithy/node-config-provider" "^4.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@smithy/util-hex-encoding@^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz#dd449a6452cffb37c5b1807ec2525bb4be551e8d"
@@ -2749,6 +3189,15 @@
   integrity sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==
   dependencies:
     "@smithy/service-error-classification" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-retry@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.0.3.tgz#42d54b3a100915b61c6f9bee43c966e96139584d"
+  integrity sha512-DPuYjZQDXmKr/sNvy9Spu8R/ESa2e22wXZzSAY6NkjOLj6spbIje/Aq8rT97iUMdDj0qHMRIe+bTxvlU74d9Ng==
+  dependencies:
+    "@smithy/service-error-classification" "^4.0.3"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
@@ -3824,7 +4273,7 @@ before-after-hook@^2.2.0:
 
 before-after-hook@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz#d5665a5fa8b62294a5aa0a499f933f4a1016195d"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-3.0.2.tgz#d5665a5fa8b62294a5aa0a499f933f4a1016195d"
   integrity sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==
 
 bin-links@^4.0.4:
@@ -5284,7 +5733,7 @@ external-editor@^3.0.3:
 
 fast-content-type-parse@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz#c236124534ee2cb427c8d8e5ba35a4856947847b"
+  resolved "https://registry.yarnpkg.com/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz#c236124534ee2cb427c8d8e5ba35a4856947847b"
   integrity sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
@@ -10717,7 +11166,7 @@ universal-user-agent@^6.0.0:
 
 universal-user-agent@^7.0.0, universal-user-agent@^7.0.2:
   version "7.0.2"
-  resolved "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz#52e7d0e9b3dc4df06cc33cb2b9fd79041a54827e"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-7.0.2.tgz#52e7d0e9b3dc4df06cc33cb2b9fd79041a54827e"
   integrity sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==
 
 universalify@^0.1.0:


### PR DESCRIPTION
This PR configures a group of acceptance tests under the `app-framework-test-app` package. Run `npm run accept` to run acceptance tests under this package. The PR adds a top-level `TESTING.md` file with common prerequisites and setup instructions, along with package-specific `TESTING.md` files in both `app-framework-test-app` and `app-framework-ops-tools` for detailed instructions on running their respective tests.

The acceptance tests implement end-to-end validation for retrieving an App token from the Credential Manager using the Smithy-generated client with SigV4-signed API calls.

Prerequisites:
1. Deploy the Credential Manager infrastructure.
2. Import the GitHub App private key into AWS KMS.

Test Cases:
A successful (happy path) request to retrieve an app token.
A request with appId set to 0.
A request with a non-existent appId.
A request with broken credentials in the SigV4 signature.

Result:
All acceptance tests passed successfully.

