### PR TITLE
feat: Add missing repository information for packages

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -235,6 +235,7 @@ const theAppFrameworkOpsTools = new typescript.TypeScriptProject({
   outdir: "src/packages/app-framework-ops-tools",
   parent: project,
   projenrcTs: false,
+  repository: projectMetadata.repositoryUrl,
   deps: [
     "@aws-sdk/client-resource-groups-tagging-api",
     "@aws-sdk/client-kms",
@@ -264,6 +265,7 @@ const theAppFrameworkTestApp = new awscdk.AwsCdkTypeScriptApp({
   outdir: "src/packages/app-framework-test-app",
   parent: project,
   projenrcTs: false,
+  repository: projectMetadata.repositoryUrl,
   cdkVersion: "2.184.1",
   deps: [
     "@aws-sdk/hash-node",

--- a/src/packages/app-framework-ops-tools/package.json
+++ b/src/packages/app-framework-ops-tools/package.json
@@ -1,5 +1,9 @@
 {
   "name": "app-framework-ops-tools",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/amazon-ospo/framework-for-github-app-on-aws.git"
+  },
   "scripts": {
     "accept": "npx projen accept",
     "build": "npx projen build",

--- a/src/packages/app-framework-test-app/package.json
+++ b/src/packages/app-framework-test-app/package.json
@@ -1,5 +1,9 @@
 {
   "name": "app-framework-test-app",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/amazon-ospo/framework-for-github-app-on-aws.git"
+  },
   "scripts": {
     "accept": "npx projen accept",
     "build": "npx projen build",


### PR DESCRIPTION
For publishing to package managers, individual packages' `package.json` require repository information. Added repo info for `app-framework-ops-tools` and `app-framework-test-app` packages.