### PR TITLE
feat: Adding cfn mapping output for installation access token endpoint

### DIFF
--- a/src/packages/app-framework-test-app/src/main.ts
+++ b/src/packages/app-framework-test-app/src/main.ts
@@ -13,9 +13,15 @@ export class TheAppFrameworkTestStack extends Stack {
       {},
     );
     const appTokenUrl = credentialManager.appTokenEndpoint;
+    const installationAccessTokenUrl =
+      credentialManager.installationAccessTokenEndpoint;
     new CfnOutput(this, 'AppTokenEndpoint', {
       value: appTokenUrl,
       exportName: 'AppTokenEndpoint',
+    });
+    new CfnOutput(this, 'InstallationAccessTokenEndpoint', {
+      value: installationAccessTokenUrl,
+      exportName: 'InstallationAccessTokenEndpoint',
     });
   }
 }


### PR DESCRIPTION
### Notes

Added in CFN mappng for installation access token endpoint such that when deploying cdk infrastructure the output shows both App token endpoint and Installation Access token endpoint.

### Testing

Installation access token endpoint appears successfully when deploying cdk code