### PR TITLE
feat: Adding in acceptance tests for installation access token endpoint

### DIFF
--- a/src/packages/app-framework-test-app/src/main.ts
+++ b/src/packages/app-framework-test-app/src/main.ts
@@ -1,5 +1,5 @@
 import { CredentialManager } from '@aws/framework-for-github-app-on-aws';
-import { App, Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { App, Stack, StackProps, CfnOutput, Aws } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 // CDK App entry for @aws/framework-for-github-app-on-aws acceptance test.
 // This stack is intended for testing @aws/framework-for-github-app-on-aws library.
@@ -22,6 +22,10 @@ export class TheAppFrameworkTestStack extends Stack {
     new CfnOutput(this, 'InstallationAccessTokenEndpoint', {
       value: installationAccessTokenUrl,
       exportName: 'InstallationAccessTokenEndpoint',
+    });
+    new CfnOutput(this, 'Region', {
+      value: Aws.REGION,
+      exportName: 'Region',
     });
   }
 }

--- a/src/packages/app-framework-test-app/test/TESTING.md
+++ b/src/packages/app-framework-test-app/test/TESTING.md
@@ -58,13 +58,16 @@ and store the output in `cdk-output.json` file:
 
 Make sure the `cdk-output.json` file
 is present at `app-framework-test-app` package
-and includes a valid AppTokenEndpoint value.
+and includes a valid AppTokenEndpoint value and
+a valid InstallationAccessTokenEndpoint value.
 The generated `cdk-output.json` file should include:
 
 ```sh
     {
       "the-app-framework-test-stack": {
-        "AppTokenEndpoint": <your-lambda-function-url-for-app-token>
+        "AppTokenEndpoint": <your-lambda-function-url-for-app-token>,
+        "InstallationAccessTokenEndpoint": <your-lambda-function-url-for-installation-token>,
+        "Region": <your-aws-account-region>
       }
     }
 ```
@@ -82,6 +85,7 @@ Before running the tests, set the required environment variable:
 
 ```sh
     export GITHUB_APPID=<your-github-app-id>
+    export GITHUB_NODEID=<your-github-node-id>
 ```
 
 ## Running Tests

--- a/src/packages/app-framework-test-app/test/getAppToken.accept.test.ts
+++ b/src/packages/app-framework-test-app/test/getAppToken.accept.test.ts
@@ -28,7 +28,7 @@ describe('Smithy client for app token API', () => {
     }
     const output = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
     endpoint = output['the-app-framework-test-stack'].AppTokenEndpoint;
-    region = 'us-west-2';
+    region = output['the-app-framework-test-stack'].Region;
     if (!endpoint) {
       throw new Error(
         `Invalid or missing endpoint in cdk-output.json: ${JSON.stringify(endpoint)}`,

--- a/src/packages/app-framework-test-app/test/getInstallationAccessToken.accept.test.ts
+++ b/src/packages/app-framework-test-app/test/getInstallationAccessToken.accept.test.ts
@@ -1,0 +1,180 @@
+import * as fs from 'fs';
+import {
+  AppFrameworkClient,
+  GetInstallationTokenCommand,
+} from '@aws/app-framework-client';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+/**
+ @group accept
+ */
+describe('Smithy client for installation access token API', () => {
+  let endpoint: string;
+  let region: string;
+  const validAppId = Number(process.env.GITHUB_APPID);
+  const validNodeId = process.env.GITHUB_NODEID;
+  beforeAll(() => {
+    const outputPath = './cdk-output.json';
+    if (!fs.existsSync(outputPath)) {
+      throw new Error(`
+            Can not find cdk-output.json file. 
+            To run acceptance tests, 
+            please get the Installation Access Token endpoint from deployed Credential Manager Component:
+      
+            Run 'npx projen deploy --outputs-file ./cdk-output.json'
+      
+            Then run the tests again with:
+            npm run accept
+      `);
+    }
+    const output = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    endpoint =
+      output['the-app-framework-test-stack'].InstallationAccessTokenEndpoint;
+    region = output['the-app-framework-test-stack'].Region;
+    if (!endpoint) {
+      throw new Error(
+        `Invalid or missing endpoint in cdk-output.json: ${JSON.stringify(endpoint)}`,
+      );
+    }
+    if (!validAppId || !validNodeId) {
+      throw new Error(`
+            Missing required environment variables.
+            To run acceptance tests, please set the following environment variables:
+            
+            export GITHUB_APPID=<your-github-app-id>
+            export GITHUB_NODEID=<your-github-node-id>
+
+            Current values:
+            APPID: ${validAppId ? validAppId : 'NOT_SET'}
+            NODEID: ${validNodeId ? validNodeId : 'NOT_SET'}
+
+            Then run the tests again with:
+            npm run accept
+        `);
+    }
+  });
+  it('should return a valid installation access token for a valid appId and nodeId', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    const command = new GetInstallationTokenCommand({
+      appId: validAppId,
+      nodeId: validNodeId,
+    });
+    const response = await client.send(command);
+    expect(response).toHaveProperty('appId');
+    expect(typeof response.appId).toBe('number');
+    expect(response).toHaveProperty('nodeId');
+    expect(typeof response.nodeId).toBe('string');
+    expect(response).toHaveProperty('installationToken');
+    expect(typeof response.installationToken).toBe('string');
+    expect(response).toHaveProperty('expirationTime');
+  });
+  it('should return a validation error for appId=0', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    await expect(
+      client.send(
+        new GetInstallationTokenCommand({ appId: 0, nodeId: validNodeId }),
+      ),
+    ).rejects.toThrow(
+      "1 validation error detected. Value at '/appId' failed to satisfy constraint: Member must be greater than or equal to 1",
+    );
+  });
+  it('should return a validation error for nodeId is an empty string', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    await expect(
+      client.send(
+        new GetInstallationTokenCommand({ appId: validAppId, nodeId: '' }),
+      ),
+    ).rejects.toThrow(
+      "1 validation error detected. Value with length 0 at '/nodeId' failed to satisfy constraint: Member must have length between 1 and 256, inclusive",
+    );
+  });
+  it('should return a validation error when nodeId is an empty string and appId=0', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    await expect(
+      client.send(new GetInstallationTokenCommand({ appId: 0, nodeId: '' })),
+    ).rejects.toThrow(
+      "2 validation errors at 2 paths detected. First failure: Value at '/appId' failed to satisfy constraint: Member must be greater than or equal to 1",
+    );
+  });
+  it('should return a not found error for a non-existent appId', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    const command = new GetInstallationTokenCommand({
+      appId: 9999999,
+      nodeId: validNodeId,
+    });
+    await expect(client.send(command)).rejects.toThrow(
+      'Invalid Request: Error: Item not found',
+    );
+  });
+  it('should return a not found error for a non-existent nodeId', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    const command = new GetInstallationTokenCommand({
+      appId: validAppId,
+      nodeId: 'Some-random',
+    });
+    await expect(client.send(command)).rejects.toThrow(
+      `Invalid Request: Error: Installation not found in response for app Id: ${validAppId} and target: Some-random`,
+    );
+  });
+  it('should return a not found error for a non-existent nodeId and appId', async () => {
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: defaultProvider(),
+      sha256: Sha256,
+    });
+    const command = new GetInstallationTokenCommand({
+      appId: 9999999,
+      nodeId: 'Some-random',
+    });
+    await expect(client.send(command)).rejects.toThrow(
+      'Invalid Request: Error: Item not found',
+    );
+  });
+  it('should fail if credentials are missing', async () => {
+    const missingCredentialsProvider = async () => {
+      throw new Error('Missing credentials');
+    };
+    const client = new AppFrameworkClient({
+      endpoint,
+      region,
+      credentials: missingCredentialsProvider,
+      sha256: Sha256,
+    });
+    const command = new GetInstallationTokenCommand({
+      appId: 1161167,
+      nodeId: 'Some-random',
+    });
+    await expect(client.send(command)).rejects.toThrow('Missing credentials');
+  });
+});

--- a/src/packages/app-framework/src/credential-manager/get-installation-access-token/getInstallationAccessToken.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installation-access-token/getInstallationAccessToken.ts
@@ -116,7 +116,7 @@ export const getInstallationIdImpl: GetInstallationId = async ({
   appToken,
 }): Promise<number> => {
   console.log(`Received inputs to get installationID: 
-    { appId: ${appId}, nodeId: ${nodeId}`);
+    { appId: ${appId}, nodeId: ${nodeId}}`);
   try {
     const installationID = await getInstallationIdFromTable({
       appId,

--- a/src/packages/app-framework/src/credential-manager/get-installation-access-token/getInstallationAccessTokenOperation.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installation-access-token/getInstallationAccessTokenOperation.ts
@@ -32,9 +32,7 @@ export const getInstallationAccessTokenOperationImpl: Operation<
     return result;
   } catch (error) {
     if (error instanceof VisibleError) {
-      throw new ClientSideError({
-        message: error.message,
-      });
+      throw new ClientSideError({ message: `Invalid Request: ${error}` });
     }
     console.error(error);
     throw new ServerSideError({ message: 'Internal Server Error' });

--- a/src/packages/app-framework/src/tableOperations.ts
+++ b/src/packages/app-framework/src/tableOperations.ts
@@ -27,7 +27,8 @@ export class TableOperations {
       const result: GetItemCommandOutput = await client.send(command);
 
       if (!result.Item) {
-        throw new NotFound(`Item not found in ${this.config.TableName}`);
+        console.error(`Item not found in ${this.config.TableName}`);
+        throw new NotFound('Item not found');
       }
 
       return unmarshall(result.Item);


### PR DESCRIPTION
### Notes
Added acceptance tests for installation access token.
I have also added in some minor changes to `NotFound` error messages in the `tableOperations.ts` file to not have the table name since customers of the smithy client would not be able to do anything with that information.
I have also added in a CFN output for the aws region the framework gets deployed to since there was previously a hard coded value for `us-west-2` which is not applicable for all of the aws accounts the framework will get deployed in.

### Testing
Acceptance tests pass as expected.