### PR TITLE
feat: add two APIs on Smithy model

### DIFF
--- a/src/packages/smithy/build/smithy/source/build-info/smithy-build-info.json
+++ b/src/packages/smithy/build/smithy/source/build-info/smithy-build-info.json
@@ -2,7 +2,9 @@
     "metadata": {},
     "operationShapeIds": [
         "framework.api#GetAppToken",
-        "framework.api#GetInstallationToken"
+        "framework.api#GetInstallationData",
+        "framework.api#GetInstallationToken",
+        "framework.api#RefreshCachedData"
     ],
     "projection": {
         "abstract": false,

--- a/src/packages/smithy/build/smithy/source/model/model.json
+++ b/src/packages/smithy/build/smithy/source/model/model.json
@@ -1889,7 +1889,13 @@
                     "target": "framework.api#GetAppToken"
                 },
                 {
+                    "target": "framework.api#GetInstallationData"
+                },
+                {
                     "target": "framework.api#GetInstallationToken"
+                },
+                {
+                    "target": "framework.api#RefreshCachedData"
                 }
             ]
         },
@@ -1944,6 +1950,52 @@
                     "traits": {
                         "smithy.api#timestampFormat": "date-time"
                     }
+                }
+            }
+        },
+        "framework.api#GetInstallationData": {
+            "type": "operation",
+            "input": {
+                "target": "framework.api#GetInstallationDataInput"
+            },
+            "output": {
+                "target": "framework.api#GetInstallationDataOutput"
+            },
+            "errors": [
+                {
+                    "target": "framework.api#ClientSideError"
+                },
+                {
+                    "target": "framework.api#ServerSideError"
+                }
+            ],
+            "traits": {
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/installations/info"
+                }
+            }
+        },
+        "framework.api#GetInstallationDataInput": {
+            "type": "structure",
+            "members": {
+                "nodeId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 256
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "framework.api#GetInstallationDataOutput": {
+            "type": "structure",
+            "members": {
+                "installations": {
+                    "target": "framework.api#InstallationDataList"
                 }
             }
         },
@@ -2007,6 +2059,67 @@
                     "target": "smithy.api#Integer"
                 },
                 "expirationTime": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                }
+            }
+        },
+        "framework.api#InstallationData": {
+            "type": "structure",
+            "members": {
+                "nodeId": {
+                    "target": "smithy.api#String"
+                },
+                "appId": {
+                    "target": "smithy.api#Integer"
+                },
+                "installationId": {
+                    "target": "smithy.api#Integer"
+                }
+            }
+        },
+        "framework.api#InstallationDataList": {
+            "type": "list",
+            "member": {
+                "target": "framework.api#InstallationData"
+            }
+        },
+        "framework.api#RefreshCachedData": {
+            "type": "operation",
+            "input": {
+                "target": "framework.api#RefreshCachedDataInput"
+            },
+            "output": {
+                "target": "framework.api#RefreshCachedDataOutput"
+            },
+            "errors": [
+                {
+                    "target": "framework.api#ClientSideError"
+                },
+                {
+                    "target": "framework.api#ServerSideError"
+                }
+            ],
+            "traits": {
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/installations/refresh"
+                }
+            }
+        },
+        "framework.api#RefreshCachedDataInput": {
+            "type": "structure",
+            "members": {}
+        },
+        "framework.api#RefreshCachedDataOutput": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String"
+                },
+                "refreshedDate": {
                     "target": "smithy.api#Timestamp",
                     "traits": {
                         "smithy.api#timestampFormat": "date-time"

--- a/src/packages/smithy/build/smithy/source/sources/credential_management.smithy
+++ b/src/packages/smithy/build/smithy/source/sources/credential_management.smithy
@@ -2,7 +2,7 @@ $version: "2.0"
 namespace framework.api
 
 resource CredentialManagementService{
-    operations: [GetInstallationToken, GetAppToken]
+    operations: [GetInstallationToken, GetAppToken, RefreshCachedData, GetInstallationData]
 }
 
 // Placeholder API endpoints
@@ -19,6 +19,20 @@ operation GetAppToken {
     input: GetAppTokenInput,
     output: GetAppTokenOutput
     errors:[ServerSideError, ClientSideError]
+}
+
+@http(method: "POST", uri: "/installations/refresh")
+operation RefreshCachedData {
+    input: RefreshCachedDataInput,
+    output: RefreshCachedDataOutput,
+    errors: [ServerSideError, ClientSideError]
+}
+
+@http(method: "POST", uri: "/installations/info")
+operation GetInstallationData {
+    input: GetInstallationDataInput,
+    output: GetInstallationDataOutput,
+    errors: [ServerSideError, ClientSideError]
 }
 
 structure GetInstallationTokenInput {
@@ -50,6 +64,33 @@ structure GetAppTokenOutput {
     appId: Integer
     @timestampFormat("date-time")
     expirationTime: Timestamp
+}
+
+structure RefreshCachedDataInput {}
+
+structure RefreshCachedDataOutput {
+    message: String
+    @timestampFormat("date-time")
+    refreshedDate: Timestamp
+}
+
+structure GetInstallationDataInput {
+    @length(min: 1, max:256)
+    @required
+    nodeId: String
+}
+
+structure InstallationData {
+    nodeId: String
+    appId: Integer
+    installationId: Integer
+}
+
+list InstallationDataList {
+    member: InstallationData
+}
+structure GetInstallationDataOutput {
+    installations: InstallationDataList
 }
 
 @httpError(500)

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/AppFramework.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/AppFramework.ts
@@ -10,16 +10,28 @@ import {
   GetAppTokenCommandOutput,
 } from "./commands/GetAppTokenCommand";
 import {
+  GetInstallationDataCommand,
+  GetInstallationDataCommandInput,
+  GetInstallationDataCommandOutput,
+} from "./commands/GetInstallationDataCommand";
+import {
   GetInstallationTokenCommand,
   GetInstallationTokenCommandInput,
   GetInstallationTokenCommandOutput,
 } from "./commands/GetInstallationTokenCommand";
+import {
+  RefreshCachedDataCommand,
+  RefreshCachedDataCommandInput,
+  RefreshCachedDataCommandOutput,
+} from "./commands/RefreshCachedDataCommand";
 import { createAggregatedClient } from "@smithy/smithy-client";
 import { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
 
 const commands = {
   GetAppTokenCommand,
+  GetInstallationDataCommand,
   GetInstallationTokenCommand,
+  RefreshCachedDataCommand,
 }
 
 export interface AppFramework {
@@ -41,6 +53,23 @@ export interface AppFramework {
   ): void;
 
   /**
+   * @see {@link GetInstallationDataCommand}
+   */
+  getInstallationData(
+    args: GetInstallationDataCommandInput,
+    options?: __HttpHandlerOptions,
+  ): Promise<GetInstallationDataCommandOutput>;
+  getInstallationData(
+    args: GetInstallationDataCommandInput,
+    cb: (err: any, data?: GetInstallationDataCommandOutput) => void
+  ): void;
+  getInstallationData(
+    args: GetInstallationDataCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: GetInstallationDataCommandOutput) => void
+  ): void;
+
+  /**
    * @see {@link GetInstallationTokenCommand}
    */
   getInstallationToken(
@@ -55,6 +84,24 @@ export interface AppFramework {
     args: GetInstallationTokenCommandInput,
     options: __HttpHandlerOptions,
     cb: (err: any, data?: GetInstallationTokenCommandOutput) => void
+  ): void;
+
+  /**
+   * @see {@link RefreshCachedDataCommand}
+   */
+  refreshCachedData(): Promise<RefreshCachedDataCommandOutput>;
+  refreshCachedData(
+    args: RefreshCachedDataCommandInput,
+    options?: __HttpHandlerOptions,
+  ): Promise<RefreshCachedDataCommandOutput>;
+  refreshCachedData(
+    args: RefreshCachedDataCommandInput,
+    cb: (err: any, data?: RefreshCachedDataCommandOutput) => void
+  ): void;
+  refreshCachedData(
+    args: RefreshCachedDataCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: RefreshCachedDataCommandOutput) => void
   ): void;
 
 }

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/AppFrameworkClient.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/AppFrameworkClient.ts
@@ -11,9 +11,17 @@ import {
   GetAppTokenCommandOutput,
 } from "./commands/GetAppTokenCommand";
 import {
+  GetInstallationDataCommandInput,
+  GetInstallationDataCommandOutput,
+} from "./commands/GetInstallationDataCommand";
+import {
   GetInstallationTokenCommandInput,
   GetInstallationTokenCommandOutput,
 } from "./commands/GetInstallationTokenCommand";
+import {
+  RefreshCachedDataCommandInput,
+  RefreshCachedDataCommandOutput,
+} from "./commands/RefreshCachedDataCommand";
 import { getRuntimeConfig as __getRuntimeConfig } from "./runtimeConfig";
 import {
   RuntimeExtension,
@@ -84,14 +92,18 @@ export { __Client }
  */
 export type ServiceInputTypes =
   | GetAppTokenCommandInput
-  | GetInstallationTokenCommandInput;
+  | GetInstallationDataCommandInput
+  | GetInstallationTokenCommandInput
+  | RefreshCachedDataCommandInput;
 
 /**
  * @public
  */
 export type ServiceOutputTypes =
   | GetAppTokenCommandOutput
-  | GetInstallationTokenCommandOutput;
+  | GetInstallationDataCommandOutput
+  | GetInstallationTokenCommandOutput
+  | RefreshCachedDataCommandOutput;
 
 /**
  * @public

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/GetInstallationDataCommand.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/GetInstallationDataCommand.ts
@@ -1,0 +1,110 @@
+// @ts-nocheck
+// smithy-typescript generated code
+import {
+  AppFrameworkClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../AppFrameworkClient";
+import {
+  GetInstallationDataInput,
+  GetInstallationDataOutput,
+} from "../models/models_0";
+import {
+  de_GetInstallationDataCommand,
+  se_GetInstallationDataCommand,
+} from "../protocols/Aws_restJson1";
+import { getSerdePlugin } from "@smithy/middleware-serde";
+import { Command as $Command } from "@smithy/smithy-client";
+import { MetadataBearer as __MetadataBearer } from "@smithy/types";
+
+/**
+ * @public
+ */
+export type { __MetadataBearer };
+export { $Command };
+/**
+ * @public
+ *
+ * The input for {@link GetInstallationDataCommand}.
+ */
+export interface GetInstallationDataCommandInput extends GetInstallationDataInput {}
+/**
+ * @public
+ *
+ * The output of {@link GetInstallationDataCommand}.
+ */
+export interface GetInstallationDataCommandOutput extends GetInstallationDataOutput, __MetadataBearer {}
+
+/**
+ * @public
+ *
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { AppFrameworkClient, GetInstallationDataCommand } from "@aws/app-framework-for-github-apps-on-aws-client"; // ES Modules import
+ * // const { AppFrameworkClient, GetInstallationDataCommand } = require("@aws/app-framework-for-github-apps-on-aws-client"); // CommonJS import
+ * const client = new AppFrameworkClient(config);
+ * const input = { // GetInstallationDataInput
+ *   nodeId: "STRING_VALUE", // required
+ * };
+ * const command = new GetInstallationDataCommand(input);
+ * const response = await client.send(command);
+ * // { // GetInstallationDataOutput
+ * //   installations: [ // InstallationDataList
+ * //     { // InstallationData
+ * //       nodeId: "STRING_VALUE",
+ * //       appId: Number("int"),
+ * //       installationId: Number("int"),
+ * //     },
+ * //   ],
+ * // };
+ *
+ * ```
+ *
+ * @param GetInstallationDataCommandInput - {@link GetInstallationDataCommandInput}
+ * @returns {@link GetInstallationDataCommandOutput}
+ * @see {@link GetInstallationDataCommandInput} for command's `input` shape.
+ * @see {@link GetInstallationDataCommandOutput} for command's `response` shape.
+ * @see {@link AppFrameworkClientResolvedConfig | config} for AppFrameworkClient's `config` shape.
+ *
+ * @throws {@link ServerSideError} (server fault)
+ *
+ * @throws {@link ClientSideError} (client fault)
+ *
+ * @throws {@link ValidationException} (client fault)
+ *  A standard error for input validation failures.
+ * This should be thrown by services when a member of the input structure
+ * falls outside of the modeled or documented constraints.
+ *
+ * @throws {@link AppFrameworkServiceException}
+ * <p>Base exception class for all service exceptions from AppFramework service.</p>
+ *
+ *
+ */
+export class GetInstallationDataCommand extends $Command.classBuilder<GetInstallationDataCommandInput, GetInstallationDataCommandOutput, AppFrameworkClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
+      .m(function (this: any, Command: any, cs: any, config: AppFrameworkClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+      ];
+  })
+  .s("AppFramework", "GetInstallationData", {
+
+  })
+  .n("AppFrameworkClient", "GetInstallationDataCommand")
+  .f(void 0, void 0)
+  .ser(se_GetInstallationDataCommand)
+  .de(de_GetInstallationDataCommand)
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
+      input: GetInstallationDataInput;
+      output: GetInstallationDataOutput;
+  };
+  sdk: {
+      input: GetInstallationDataCommandInput;
+      output: GetInstallationDataCommandOutput;
+  };
+};
+}

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/RefreshCachedDataCommand.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/RefreshCachedDataCommand.ts
@@ -1,0 +1,103 @@
+// @ts-nocheck
+// smithy-typescript generated code
+import {
+  AppFrameworkClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../AppFrameworkClient";
+import {
+  RefreshCachedDataInput,
+  RefreshCachedDataOutput,
+} from "../models/models_0";
+import {
+  de_RefreshCachedDataCommand,
+  se_RefreshCachedDataCommand,
+} from "../protocols/Aws_restJson1";
+import { getSerdePlugin } from "@smithy/middleware-serde";
+import { Command as $Command } from "@smithy/smithy-client";
+import { MetadataBearer as __MetadataBearer } from "@smithy/types";
+
+/**
+ * @public
+ */
+export type { __MetadataBearer };
+export { $Command };
+/**
+ * @public
+ *
+ * The input for {@link RefreshCachedDataCommand}.
+ */
+export interface RefreshCachedDataCommandInput extends RefreshCachedDataInput {}
+/**
+ * @public
+ *
+ * The output of {@link RefreshCachedDataCommand}.
+ */
+export interface RefreshCachedDataCommandOutput extends RefreshCachedDataOutput, __MetadataBearer {}
+
+/**
+ * @public
+ *
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { AppFrameworkClient, RefreshCachedDataCommand } from "@aws/app-framework-for-github-apps-on-aws-client"; // ES Modules import
+ * // const { AppFrameworkClient, RefreshCachedDataCommand } = require("@aws/app-framework-for-github-apps-on-aws-client"); // CommonJS import
+ * const client = new AppFrameworkClient(config);
+ * const input = {};
+ * const command = new RefreshCachedDataCommand(input);
+ * const response = await client.send(command);
+ * // { // RefreshCachedDataOutput
+ * //   message: "STRING_VALUE",
+ * //   refreshedDate: new Date("TIMESTAMP"),
+ * // };
+ *
+ * ```
+ *
+ * @param RefreshCachedDataCommandInput - {@link RefreshCachedDataCommandInput}
+ * @returns {@link RefreshCachedDataCommandOutput}
+ * @see {@link RefreshCachedDataCommandInput} for command's `input` shape.
+ * @see {@link RefreshCachedDataCommandOutput} for command's `response` shape.
+ * @see {@link AppFrameworkClientResolvedConfig | config} for AppFrameworkClient's `config` shape.
+ *
+ * @throws {@link ServerSideError} (server fault)
+ *
+ * @throws {@link ClientSideError} (client fault)
+ *
+ * @throws {@link ValidationException} (client fault)
+ *  A standard error for input validation failures.
+ * This should be thrown by services when a member of the input structure
+ * falls outside of the modeled or documented constraints.
+ *
+ * @throws {@link AppFrameworkServiceException}
+ * <p>Base exception class for all service exceptions from AppFramework service.</p>
+ *
+ *
+ */
+export class RefreshCachedDataCommand extends $Command.classBuilder<RefreshCachedDataCommandInput, RefreshCachedDataCommandOutput, AppFrameworkClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes>()
+      .m(function (this: any, Command: any, cs: any, config: AppFrameworkClientResolvedConfig, o: any) {
+          return [
+
+  getSerdePlugin(config, this.serialize, this.deserialize),
+      ];
+  })
+  .s("AppFramework", "RefreshCachedData", {
+
+  })
+  .n("AppFrameworkClient", "RefreshCachedDataCommand")
+  .f(void 0, void 0)
+  .ser(se_RefreshCachedDataCommand)
+  .de(de_RefreshCachedDataCommand)
+.build() {
+/** @internal type navigation helper, not in runtime. */
+declare protected static __types: {
+  api: {
+      input: {};
+      output: RefreshCachedDataOutput;
+  };
+  sdk: {
+      input: RefreshCachedDataCommandInput;
+      output: RefreshCachedDataCommandOutput;
+  };
+};
+}

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/index.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/index.ts
@@ -1,4 +1,5 @@
-// @ts-nocheck
 // smithy-typescript generated code
 export * from "./GetAppTokenCommand";
+export * from "./GetInstallationDataCommand";
 export * from "./GetInstallationTokenCommand";
+export * from "./RefreshCachedDataCommand";

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/models/models_0.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/models/models_0.ts
@@ -108,6 +108,29 @@ export class ValidationException extends __BaseException {
 /**
  * @public
  */
+export interface GetInstallationDataInput {
+  nodeId: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface InstallationData {
+  nodeId?: string | undefined;
+  appId?: number | undefined;
+  installationId?: number | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetInstallationDataOutput {
+  installations?: (InstallationData)[] | undefined;
+}
+
+/**
+ * @public
+ */
 export interface GetInstallationTokenInput {
   appId: number | undefined;
   nodeId: string | undefined;
@@ -121,4 +144,18 @@ export interface GetInstallationTokenOutput {
   nodeId?: string | undefined;
   appId?: number | undefined;
   expirationTime?: Date | undefined;
+}
+
+/**
+ * @public
+ */
+export interface RefreshCachedDataInput {
+}
+
+/**
+ * @public
+ */
+export interface RefreshCachedDataOutput {
+  message?: string | undefined;
+  refreshedDate?: Date | undefined;
 }

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/protocols/Aws_restJson1.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/protocols/Aws_restJson1.ts
@@ -5,9 +5,17 @@ import {
   GetAppTokenCommandOutput,
 } from "../commands/GetAppTokenCommand";
 import {
+  GetInstallationDataCommandInput,
+  GetInstallationDataCommandOutput,
+} from "../commands/GetInstallationDataCommand";
+import {
   GetInstallationTokenCommandInput,
   GetInstallationTokenCommandOutput,
 } from "../commands/GetInstallationTokenCommand";
+import {
+  RefreshCachedDataCommandInput,
+  RefreshCachedDataCommandOutput,
+} from "../commands/RefreshCachedDataCommand";
 import { AppFrameworkServiceException as __BaseException } from "../models/AppFrameworkServiceException";
 import {
   ClientSideError,
@@ -66,6 +74,28 @@ export const se_GetAppTokenCommand = async(
 }
 
 /**
+ * serializeAws_restJson1GetInstallationDataCommand
+ */
+export const se_GetInstallationDataCommand = async(
+  input: GetInstallationDataCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {
+    'content-type': 'application/json',
+  };
+  b.bp("/installations/info");
+  let body: any;
+  body = JSON.stringify(take(input, {
+    'nodeId': [],
+  }));
+  b.m("POST")
+  .h(headers)
+  .b(body);
+  return b.build();
+}
+
+/**
  * serializeAws_restJson1GetInstallationTokenCommand
  */
 export const se_GetInstallationTokenCommand = async(
@@ -82,6 +112,24 @@ export const se_GetInstallationTokenCommand = async(
     'appId': [],
     'nodeId': [],
   }));
+  b.m("POST")
+  .h(headers)
+  .b(body);
+  return b.build();
+}
+
+/**
+ * serializeAws_restJson1RefreshCachedDataCommand
+ */
+export const se_RefreshCachedDataCommand = async(
+  input: RefreshCachedDataCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {
+  };
+  b.bp("/installations/refresh");
+  let body: any;
   b.m("POST")
   .h(headers)
   .b(body);
@@ -112,6 +160,27 @@ export const de_GetAppTokenCommand = async(
 }
 
 /**
+ * deserializeAws_restJson1GetInstallationDataCommand
+ */
+export const de_GetInstallationDataCommand = async(
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<GetInstallationDataCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  const data: Record<string, any> = __expectNonNull((__expectObject(await parseBody(output.body, context))), "body");
+  const doc = take(data, {
+    'installations': _json,
+  });
+  Object.assign(contents, doc);
+  return contents;
+}
+
+/**
  * deserializeAws_restJson1GetInstallationTokenCommand
  */
 export const de_GetInstallationTokenCommand = async(
@@ -130,6 +199,28 @@ export const de_GetInstallationTokenCommand = async(
     'expirationTime': _ => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
     'installationToken': __expectString,
     'nodeId': __expectString,
+  });
+  Object.assign(contents, doc);
+  return contents;
+}
+
+/**
+ * deserializeAws_restJson1RefreshCachedDataCommand
+ */
+export const de_RefreshCachedDataCommand = async(
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<RefreshCachedDataCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  const data: Record<string, any> = __expectNonNull((__expectObject(await parseBody(output.body, context))), "body");
+  const doc = take(data, {
+    'message': __expectString,
+    'refreshedDate': _ => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
   });
   Object.assign(contents, doc);
   return contents;
@@ -231,6 +322,10 @@ const de_CommandError = async(
     });
     return __decorateServiceException(exception, parsedOutput.body);
   };
+
+  // de_InstallationData omitted.
+
+  // de_InstallationDataList omitted.
 
   // de_ValidationExceptionField omitted.
 

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/models/models_0.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/models/models_0.ts
@@ -2,6 +2,8 @@
 // smithy-typescript generated code
 import {
   ServiceException as __BaseException,
+  CompositeCollectionValidator as __CompositeCollectionValidator,
+  CompositeStructureValidator as __CompositeStructureValidator,
   CompositeValidator as __CompositeValidator,
   LengthValidator as __LengthValidator,
   MultiConstraintValidator as __MultiConstraintValidator,
@@ -208,6 +210,125 @@ export class ValidationException extends __BaseException {
 /**
  * @public
  */
+export interface GetInstallationDataInput {
+  nodeId: string | undefined;
+}
+
+export namespace GetInstallationDataInput {
+  const memberValidators : {
+    nodeId?: __MultiConstraintValidator<string>,
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: GetInstallationDataInput, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "nodeId": {
+            memberValidators["nodeId"] = new __CompositeValidator<string>([
+              new __RequiredValidator(),
+              new __LengthValidator(1, 256),
+            ]);
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+      ...getMemberValidator("nodeId").validate(obj.nodeId, `${path}/nodeId`),
+    ];
+  }
+}
+
+/**
+ * @public
+ */
+export interface InstallationData {
+  nodeId?: string | undefined;
+  appId?: number | undefined;
+  installationId?: number | undefined;
+}
+
+export namespace InstallationData {
+  const memberValidators : {
+    nodeId?: __MultiConstraintValidator<string>,
+    appId?: __MultiConstraintValidator<number>,
+    installationId?: __MultiConstraintValidator<number>,
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: InstallationData, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "nodeId": {
+            memberValidators["nodeId"] = new __NoOpValidator();
+            break;
+          }
+          case "appId": {
+            memberValidators["appId"] = new __NoOpValidator();
+            break;
+          }
+          case "installationId": {
+            memberValidators["installationId"] = new __NoOpValidator();
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+      ...getMemberValidator("nodeId").validate(obj.nodeId, `${path}/nodeId`),
+      ...getMemberValidator("appId").validate(obj.appId, `${path}/appId`),
+      ...getMemberValidator("installationId").validate(obj.installationId, `${path}/installationId`),
+    ];
+  }
+}
+
+/**
+ * @public
+ */
+export interface GetInstallationDataOutput {
+  installations?: (InstallationData)[] | undefined;
+}
+
+export namespace GetInstallationDataOutput {
+  const memberValidators : {
+    installations?: __MultiConstraintValidator<Iterable<InstallationData>>,
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: GetInstallationDataOutput, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "installations": {
+            memberValidators["installations"] = new __CompositeCollectionValidator<InstallationData>(
+              new __NoOpValidator(),
+              new __CompositeStructureValidator<InstallationData>(
+                new __NoOpValidator(),
+                InstallationData.validate
+              )
+            );
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+      ...getMemberValidator("installations").validate(obj.installations, `${path}/installations`),
+    ];
+  }
+}
+
+/**
+ * @public
+ */
 export interface GetInstallationTokenInput {
   appId: number | undefined;
   nodeId: string | undefined;
@@ -299,6 +420,70 @@ export namespace GetInstallationTokenOutput {
       ...getMemberValidator("nodeId").validate(obj.nodeId, `${path}/nodeId`),
       ...getMemberValidator("appId").validate(obj.appId, `${path}/appId`),
       ...getMemberValidator("expirationTime").validate(obj.expirationTime, `${path}/expirationTime`),
+    ];
+  }
+}
+
+/**
+ * @public
+ */
+export interface RefreshCachedDataInput {
+}
+
+export namespace RefreshCachedDataInput {
+  const memberValidators : {
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: RefreshCachedDataInput, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+    ];
+  }
+}
+
+/**
+ * @public
+ */
+export interface RefreshCachedDataOutput {
+  message?: string | undefined;
+  refreshedDate?: Date | undefined;
+}
+
+export namespace RefreshCachedDataOutput {
+  const memberValidators : {
+    message?: __MultiConstraintValidator<string>,
+    refreshedDate?: __MultiConstraintValidator<Date>,
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: RefreshCachedDataOutput, path: string = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "message": {
+            memberValidators["message"] = new __NoOpValidator();
+            break;
+          }
+          case "refreshedDate": {
+            memberValidators["refreshedDate"] = new __NoOpValidator();
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!!;
+    }
+    return [
+      ...getMemberValidator("message").validate(obj.message, `${path}/message`),
+      ...getMemberValidator("refreshedDate").validate(obj.refreshedDate, `${path}/refreshedDate`),
     ];
   }
 }

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/protocols/Aws_restJson1.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/protocols/Aws_restJson1.ts
@@ -2,6 +2,7 @@
 // smithy-typescript generated code
 import {
   ClientSideError,
+  InstallationData,
   ServerSideError,
   ValidationException,
   ValidationExceptionField,
@@ -11,9 +12,17 @@ import {
   GetAppTokenServerOutput,
 } from "../server/operations/GetAppToken";
 import {
+  GetInstallationDataServerInput,
+  GetInstallationDataServerOutput,
+} from "../server/operations/GetInstallationData";
+import {
   GetInstallationTokenServerInput,
   GetInstallationTokenServerOutput,
 } from "../server/operations/GetInstallationToken";
+import {
+  RefreshCachedDataServerInput,
+  RefreshCachedDataServerOutput,
+} from "../server/operations/RefreshCachedData";
 import {
   loadRestJsonErrorCode,
   parseJsonBody as parseBody,
@@ -78,6 +87,34 @@ export const deserializeGetAppTokenRequest = async(
   return contents;
 }
 
+export const deserializeGetInstallationDataRequest = async(
+  output: __HttpRequest,
+  context: __SerdeContext
+): Promise<GetInstallationDataServerInput> => {
+  const contentTypeHeaderKey: string | undefined = Object.keys(output.headers).find(key => key.toLowerCase() === 'content-type');
+  if (contentTypeHeaderKey != null) {
+    const contentType = output.headers[contentTypeHeaderKey];
+    if (contentType !== undefined && contentType !== "application/json") {
+      throw new __UnsupportedMediaTypeException();
+    };
+  };
+  const acceptHeaderKey: string | undefined = Object.keys(output.headers).find(key => key.toLowerCase() === 'accept');
+  if (acceptHeaderKey != null) {
+    const accept = output.headers[acceptHeaderKey];
+    if (!__acceptMatches(accept, "application/json")) {
+      throw new __NotAcceptableException();
+    };
+  };
+  const contents: any = map({
+  });
+  const data: Record<string, any> = __expectNonNull((__expectObject(await parseBody(output.body, context))), "body");
+  const doc = take(data, {
+    'nodeId': __expectString,
+  });
+  Object.assign(contents, doc);
+  return contents;
+}
+
 export const deserializeGetInstallationTokenRequest = async(
   output: __HttpRequest,
   context: __SerdeContext
@@ -104,6 +141,30 @@ export const deserializeGetInstallationTokenRequest = async(
     'nodeId': __expectString,
   });
   Object.assign(contents, doc);
+  return contents;
+}
+
+export const deserializeRefreshCachedDataRequest = async(
+  output: __HttpRequest,
+  context: __SerdeContext
+): Promise<RefreshCachedDataServerInput> => {
+  const contentTypeHeaderKey: string | undefined = Object.keys(output.headers).find(key => key.toLowerCase() === 'content-type');
+  if (contentTypeHeaderKey != null) {
+    const contentType = output.headers[contentTypeHeaderKey];
+    if (contentType !== undefined && contentType !== "application/json") {
+      throw new __UnsupportedMediaTypeException();
+    };
+  };
+  const acceptHeaderKey: string | undefined = Object.keys(output.headers).find(key => key.toLowerCase() === 'accept');
+  if (acceptHeaderKey != null) {
+    const accept = output.headers[acceptHeaderKey];
+    if (!__acceptMatches(accept, "application/json")) {
+      throw new __NotAcceptableException();
+    };
+  };
+  const contents: any = map({
+  });
+  await collectBody(output.body, context);
   return contents;
 }
 
@@ -142,6 +203,39 @@ export const serializeGetAppTokenResponse = async(
   });
 }
 
+export const serializeGetInstallationDataResponse = async(
+  input: GetInstallationDataServerOutput,
+  ctx: ServerSerdeContext
+): Promise<__HttpResponse> => {
+  const context: __SerdeContext = {
+    ...ctx,
+    endpoint: () => Promise.resolve({
+      protocol: '',
+      hostname: '',
+      path: '',
+    }),
+  }
+  let statusCode: number = 200
+  let headers: any = map({}, isSerializableHeaderValue, {
+    'content-type': 'application/json',
+  });
+  let body: any;
+  body = JSON.stringify(take(input, {
+    'installations': _ => se_InstallationDataList(_, context),
+  }));
+  if (body && Object.keys(headers).map((str) => str.toLowerCase()).indexOf('content-length') === -1) {
+    const length = calculateBodyLength(body);
+    if (length !== undefined) {
+      headers = { ...headers, 'content-length': String(length) };
+    }
+  }
+  return new __HttpResponse({
+    headers,
+    body,
+    statusCode,
+  });
+}
+
 export const serializeGetInstallationTokenResponse = async(
   input: GetInstallationTokenServerOutput,
   ctx: ServerSerdeContext
@@ -164,6 +258,40 @@ export const serializeGetInstallationTokenResponse = async(
     'expirationTime': _ => __serializeDateTime(_),
     'installationToken': [],
     'nodeId': [],
+  }));
+  if (body && Object.keys(headers).map((str) => str.toLowerCase()).indexOf('content-length') === -1) {
+    const length = calculateBodyLength(body);
+    if (length !== undefined) {
+      headers = { ...headers, 'content-length': String(length) };
+    }
+  }
+  return new __HttpResponse({
+    headers,
+    body,
+    statusCode,
+  });
+}
+
+export const serializeRefreshCachedDataResponse = async(
+  input: RefreshCachedDataServerOutput,
+  ctx: ServerSerdeContext
+): Promise<__HttpResponse> => {
+  const context: __SerdeContext = {
+    ...ctx,
+    endpoint: () => Promise.resolve({
+      protocol: '',
+      hostname: '',
+      path: '',
+    }),
+  }
+  let statusCode: number = 200
+  let headers: any = map({}, isSerializableHeaderValue, {
+    'content-type': 'application/json',
+  });
+  let body: any;
+  body = JSON.stringify(take(input, {
+    'message': [],
+    'refreshedDate': _ => __serializeDateTime(_),
   }));
   if (body && Object.keys(headers).map((str) => str.toLowerCase()).indexOf('content-length') === -1) {
     const length = calculateBodyLength(body);
@@ -346,6 +474,32 @@ export const serializeValidationExceptionError = async(
     headers,
     body,
     statusCode,
+  });
+}
+
+/**
+ * serializeAws_restJson1InstallationData
+ */
+const se_InstallationData = (
+  input: InstallationData,
+  context: __SerdeContext
+): any => {
+  return take(input, {
+    'appId': [],
+    'installationId': [],
+    'nodeId': [],
+  });
+}
+
+/**
+ * serializeAws_restJson1InstallationDataList
+ */
+const se_InstallationDataList = (
+  input: (InstallationData)[],
+  context: __SerdeContext
+): any => {
+  return input.filter((e: any) => e != null).map(entry => {
+    return se_InstallationData(entry, context);
   });
 }
 

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/server/AppFrameworkService.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/server/AppFrameworkService.ts
@@ -7,10 +7,20 @@ import {
   GetAppTokenServerInput,
 } from "./operations/GetAppToken";
 import {
+  GetInstallationData,
+  GetInstallationDataSerializer,
+  GetInstallationDataServerInput,
+} from "./operations/GetInstallationData";
+import {
   GetInstallationToken,
   GetInstallationTokenSerializer,
   GetInstallationTokenServerInput,
 } from "./operations/GetInstallationToken";
+import {
+  RefreshCachedData,
+  RefreshCachedDataSerializer,
+  RefreshCachedDataServerInput,
+} from "./operations/RefreshCachedData";
 import {
   InternalFailureException as __InternalFailureException,
   Mux as __Mux,
@@ -48,10 +58,12 @@ import {
   toUtf8,
 } from "@smithy/util-utf8";
 
-export type AppFrameworkServiceOperations = "GetAppToken" | "GetInstallationToken";
+export type AppFrameworkServiceOperations = "GetAppToken" | "GetInstallationData" | "GetInstallationToken" | "RefreshCachedData";
 export interface AppFrameworkService<Context> {
   GetAppToken: GetAppToken<Context>
+  GetInstallationData: GetInstallationData<Context>
   GetInstallationToken: GetInstallationToken<Context>
+  RefreshCachedData: RefreshCachedData<Context>
 }
 const serdeContextBase = {
   base64Encoder: toBase64,
@@ -138,8 +150,14 @@ export class AppFrameworkServiceHandler<Context> implements __ServiceHandler<Con
       case "GetAppToken" : {
         return handle(request, context, "GetAppToken", this.serializerFactory("GetAppToken"), this.service.GetAppToken, this.serializeFrameworkException, GetAppTokenServerInput.validate, this.validationCustomizer);
       }
+      case "GetInstallationData" : {
+        return handle(request, context, "GetInstallationData", this.serializerFactory("GetInstallationData"), this.service.GetInstallationData, this.serializeFrameworkException, GetInstallationDataServerInput.validate, this.validationCustomizer);
+      }
       case "GetInstallationToken" : {
         return handle(request, context, "GetInstallationToken", this.serializerFactory("GetInstallationToken"), this.service.GetInstallationToken, this.serializeFrameworkException, GetInstallationTokenServerInput.validate, this.validationCustomizer);
+      }
+      case "RefreshCachedData" : {
+        return handle(request, context, "RefreshCachedData", this.serializerFactory("RefreshCachedData"), this.service.RefreshCachedData, this.serializeFrameworkException, RefreshCachedDataServerInput.validate, this.validationCustomizer);
       }
     }
   }
@@ -156,6 +174,15 @@ export const getAppFrameworkServiceHandler = <Context>(service: AppFrameworkServ
       [
       ],
       { service: "AppFramework", operation: "GetAppToken" }),
+    new httpbinding.UriSpec<"AppFramework", "GetInstallationData">(
+      'POST',
+      [
+        { type: 'path_literal', value: "installations" },
+        { type: 'path_literal', value: "info" },
+      ],
+      [
+      ],
+      { service: "AppFramework", operation: "GetInstallationData" }),
     new httpbinding.UriSpec<"AppFramework", "GetInstallationToken">(
       'POST',
       [
@@ -165,11 +192,22 @@ export const getAppFrameworkServiceHandler = <Context>(service: AppFrameworkServ
       [
       ],
       { service: "AppFramework", operation: "GetInstallationToken" }),
+    new httpbinding.UriSpec<"AppFramework", "RefreshCachedData">(
+      'POST',
+      [
+        { type: 'path_literal', value: "installations" },
+        { type: 'path_literal', value: "refresh" },
+      ],
+      [
+      ],
+      { service: "AppFramework", operation: "RefreshCachedData" }),
   ]);
   const serFn: (op: AppFrameworkServiceOperations) => __OperationSerializer<AppFrameworkService<Context>, AppFrameworkServiceOperations, __ServiceException> = (op) => {
     switch (op) {
       case "GetAppToken": return new GetAppTokenSerializer();
+      case "GetInstallationData": return new GetInstallationDataSerializer();
       case "GetInstallationToken": return new GetInstallationTokenSerializer();
+      case "RefreshCachedData": return new RefreshCachedDataSerializer();
     }
   };
   const customizer: __ValidationCustomizer<AppFrameworkServiceOperations> = (ctx, failures) => {

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/server/operations/GetInstallationData.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/server/operations/GetInstallationData.ts
@@ -1,0 +1,211 @@
+// @ts-nocheck
+// smithy-typescript generated code
+import {
+  ClientSideError,
+  GetInstallationDataInput,
+  GetInstallationDataOutput,
+  ServerSideError,
+  ValidationException,
+} from "../../models/models_0";
+import {
+  deserializeGetInstallationDataRequest,
+  serializeClientSideErrorError,
+  serializeFrameworkException,
+  serializeGetInstallationDataResponse,
+  serializeServerSideErrorError,
+  serializeValidationExceptionError,
+} from "../../protocols/Aws_restJson1";
+import { AppFrameworkService } from "../AppFrameworkService";
+import {
+  ServerSerdeContext,
+  ServiceException as __BaseException,
+  InternalFailureException as __InternalFailureException,
+  Mux as __Mux,
+  Operation as __Operation,
+  OperationInput as __OperationInput,
+  OperationOutput as __OperationOutput,
+  OperationSerializer as __OperationSerializer,
+  SerializationException as __SerializationException,
+  ServerSerdeContext as __ServerSerdeContext,
+  ServiceException as __ServiceException,
+  ServiceHandler as __ServiceHandler,
+  SmithyFrameworkException as __SmithyFrameworkException,
+  ValidationCustomizer as __ValidationCustomizer,
+  ValidationFailure as __ValidationFailure,
+  generateValidationMessage as __generateValidationMessage,
+  generateValidationSummary as __generateValidationSummary,
+  isFrameworkException as __isFrameworkException,
+  httpbinding,
+} from "@aws-smithy/server-common";
+import {
+  NodeHttpHandler,
+  streamCollector,
+} from "@smithy/node-http-handler";
+import {
+  HttpRequest as __HttpRequest,
+  HttpResponse as __HttpResponse,
+} from "@smithy/protocol-http";
+import {
+  fromBase64,
+  toBase64,
+} from "@smithy/util-base64";
+import {
+  fromUtf8,
+  toUtf8,
+} from "@smithy/util-utf8";
+
+export type GetInstallationData<Context> = __Operation<GetInstallationDataServerInput, GetInstallationDataServerOutput, Context>
+
+export interface GetInstallationDataServerInput extends GetInstallationDataInput {}
+export namespace GetInstallationDataServerInput {
+  /**
+   * @internal
+   */
+  export const validate: (obj: Parameters<typeof GetInstallationDataInput.validate>[0]) => __ValidationFailure[] = GetInstallationDataInput.validate;
+}
+export interface GetInstallationDataServerOutput extends GetInstallationDataOutput {}
+
+export type GetInstallationDataErrors = ServerSideError | ClientSideError | ValidationException
+
+export class GetInstallationDataSerializer implements __OperationSerializer<AppFrameworkService<any>, "GetInstallationData", GetInstallationDataErrors> {
+  serialize = serializeGetInstallationDataResponse;
+  deserialize = deserializeGetInstallationDataRequest;
+
+  isOperationError(error: any): error is GetInstallationDataErrors {
+    const names: GetInstallationDataErrors['name'][] = ["ServerSideError", "ClientSideError", "ValidationException"];
+    return names.includes(error.name);
+  };
+
+  serializeError(error: GetInstallationDataErrors, ctx: ServerSerdeContext): Promise<__HttpResponse> {
+    switch (error.name) {
+      case "ServerSideError": {
+        return serializeServerSideErrorError(error, ctx);
+      }
+      case "ClientSideError": {
+        return serializeClientSideErrorError(error, ctx);
+      }
+      case "ValidationException": {
+        return serializeValidationExceptionError(error, ctx);
+      }
+      default: {
+        throw error;
+      }
+    }
+  }
+
+}
+
+export const getGetInstallationDataHandler = <Context>(operation: __Operation<GetInstallationDataServerInput, GetInstallationDataServerOutput, Context>): __ServiceHandler<Context, __HttpRequest, __HttpResponse> => {
+  const mux = new httpbinding.HttpBindingMux<"AppFramework", "GetInstallationData">([
+    new httpbinding.UriSpec<"AppFramework", "GetInstallationData">(
+      'POST',
+      [
+        { type: 'path_literal', value: "installations" },
+        { type: 'path_literal', value: "info" },
+      ],
+      [
+      ],
+      { service: "AppFramework", operation: "GetInstallationData" }),
+  ]);
+  const customizer: __ValidationCustomizer<"GetInstallationData"> = (ctx, failures) => {
+    if (!failures) {
+      return undefined;
+    }
+    return {
+      name: "ValidationException",
+      $fault: "client",
+      message: __generateValidationSummary(failures),
+      fieldList: failures.map(failure => ({
+        path: failure.path,
+        message: __generateValidationMessage(failure)
+      }))
+    };
+  };
+  return new GetInstallationDataHandler(operation, mux, new GetInstallationDataSerializer(), serializeFrameworkException, customizer);
+}
+
+const serdeContextBase = {
+  base64Encoder: toBase64,
+  base64Decoder: fromBase64,
+  utf8Encoder: toUtf8,
+  utf8Decoder: fromUtf8,
+  streamCollector: streamCollector,
+  requestHandler: new NodeHttpHandler(),
+  disableHostPrefix: true
+};
+async function handle<S, O extends keyof S & string, Context>(
+  request: __HttpRequest,
+  context: Context,
+  operationName: O,
+  serializer: __OperationSerializer<S, O, __ServiceException>,
+  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
+  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
+  validationCustomizer: __ValidationCustomizer<O>
+): Promise<__HttpResponse> {
+  let input;
+  try {
+    input = await serializer.deserialize(request, {
+      endpoint: () => Promise.resolve(request), ...serdeContextBase
+    });
+  } catch (error: unknown) {
+    if (__isFrameworkException(error)) {
+      return serializeFrameworkException(error, serdeContextBase);
+    };
+    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
+  }
+  try {
+    let validationFailures = validationFn(input);
+    if (validationFailures && validationFailures.length > 0) {
+      let validationException = validationCustomizer({ operation: operationName }, validationFailures);
+      if (validationException) {
+        return serializer.serializeError(validationException, serdeContextBase);
+      }
+    }
+    let output = await operation(input, context);
+    return serializer.serialize(output, serdeContextBase);
+  } catch(error: unknown) {
+    if (serializer.isOperationError(error)) {
+      return serializer.serializeError(error, serdeContextBase);
+    }
+    console.log('Received an unexpected error', error);
+    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+  }
+}
+export class GetInstallationDataHandler<Context> implements __ServiceHandler<Context> {
+  private readonly operation: __Operation<GetInstallationDataServerInput, GetInstallationDataServerOutput, Context>;
+  private readonly mux: __Mux<"AppFramework", "GetInstallationData">;
+  private readonly serializer: __OperationSerializer<AppFrameworkService<Context>, "GetInstallationData", GetInstallationDataErrors>;
+  private readonly serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>;
+  private readonly validationCustomizer: __ValidationCustomizer<"GetInstallationData">;
+  /**
+   * Construct a GetInstallationData handler.
+   * @param operation The {@link __Operation} implementation that supplies the business logic for GetInstallationData
+   * @param mux The {@link __Mux} that verifies which service and operation are being invoked by a given {@link __HttpRequest}
+   * @param serializer An {@link __OperationSerializer} for GetInstallationData that
+   *                   handles deserialization of requests and serialization of responses
+   * @param serializeFrameworkException A function that can serialize {@link __SmithyFrameworkException}s
+   * @param validationCustomizer A {@link __ValidationCustomizer} for turning validation failures into {@link __SmithyFrameworkException}s
+   */
+  constructor(
+    operation: __Operation<GetInstallationDataServerInput, GetInstallationDataServerOutput, Context>,
+    mux: __Mux<"AppFramework", "GetInstallationData">,
+    serializer: __OperationSerializer<AppFrameworkService<Context>, "GetInstallationData", GetInstallationDataErrors>,
+    serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+    validationCustomizer: __ValidationCustomizer<"GetInstallationData">
+  ) {
+    this.operation = operation;
+    this.mux = mux;
+    this.serializer = serializer;
+    this.serializeFrameworkException = serializeFrameworkException;
+    this.validationCustomizer = validationCustomizer;
+  }
+  async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
+    const target = this.mux.match(request);
+    if (target === undefined) {
+      console.log('Received a request that did not match framework.api#AppFramework.GetInstallationData. This indicates a misconfiguration.');
+      return this.serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+    }
+    return handle(request, context, "GetInstallationData", this.serializer, this.operation, this.serializeFrameworkException, GetInstallationDataServerInput.validate, this.validationCustomizer);
+  }
+}

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/server/operations/RefreshCachedData.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/server/operations/RefreshCachedData.ts
@@ -1,0 +1,211 @@
+// @ts-nocheck
+// smithy-typescript generated code
+import {
+  ClientSideError,
+  RefreshCachedDataInput,
+  RefreshCachedDataOutput,
+  ServerSideError,
+  ValidationException,
+} from "../../models/models_0";
+import {
+  deserializeRefreshCachedDataRequest,
+  serializeClientSideErrorError,
+  serializeFrameworkException,
+  serializeRefreshCachedDataResponse,
+  serializeServerSideErrorError,
+  serializeValidationExceptionError,
+} from "../../protocols/Aws_restJson1";
+import { AppFrameworkService } from "../AppFrameworkService";
+import {
+  ServerSerdeContext,
+  ServiceException as __BaseException,
+  InternalFailureException as __InternalFailureException,
+  Mux as __Mux,
+  Operation as __Operation,
+  OperationInput as __OperationInput,
+  OperationOutput as __OperationOutput,
+  OperationSerializer as __OperationSerializer,
+  SerializationException as __SerializationException,
+  ServerSerdeContext as __ServerSerdeContext,
+  ServiceException as __ServiceException,
+  ServiceHandler as __ServiceHandler,
+  SmithyFrameworkException as __SmithyFrameworkException,
+  ValidationCustomizer as __ValidationCustomizer,
+  ValidationFailure as __ValidationFailure,
+  generateValidationMessage as __generateValidationMessage,
+  generateValidationSummary as __generateValidationSummary,
+  isFrameworkException as __isFrameworkException,
+  httpbinding,
+} from "@aws-smithy/server-common";
+import {
+  NodeHttpHandler,
+  streamCollector,
+} from "@smithy/node-http-handler";
+import {
+  HttpRequest as __HttpRequest,
+  HttpResponse as __HttpResponse,
+} from "@smithy/protocol-http";
+import {
+  fromBase64,
+  toBase64,
+} from "@smithy/util-base64";
+import {
+  fromUtf8,
+  toUtf8,
+} from "@smithy/util-utf8";
+
+export type RefreshCachedData<Context> = __Operation<RefreshCachedDataServerInput, RefreshCachedDataServerOutput, Context>
+
+export interface RefreshCachedDataServerInput extends RefreshCachedDataInput {}
+export namespace RefreshCachedDataServerInput {
+  /**
+   * @internal
+   */
+  export const validate: (obj: Parameters<typeof RefreshCachedDataInput.validate>[0]) => __ValidationFailure[] = RefreshCachedDataInput.validate;
+}
+export interface RefreshCachedDataServerOutput extends RefreshCachedDataOutput {}
+
+export type RefreshCachedDataErrors = ServerSideError | ClientSideError | ValidationException
+
+export class RefreshCachedDataSerializer implements __OperationSerializer<AppFrameworkService<any>, "RefreshCachedData", RefreshCachedDataErrors> {
+  serialize = serializeRefreshCachedDataResponse;
+  deserialize = deserializeRefreshCachedDataRequest;
+
+  isOperationError(error: any): error is RefreshCachedDataErrors {
+    const names: RefreshCachedDataErrors['name'][] = ["ServerSideError", "ClientSideError", "ValidationException"];
+    return names.includes(error.name);
+  };
+
+  serializeError(error: RefreshCachedDataErrors, ctx: ServerSerdeContext): Promise<__HttpResponse> {
+    switch (error.name) {
+      case "ServerSideError": {
+        return serializeServerSideErrorError(error, ctx);
+      }
+      case "ClientSideError": {
+        return serializeClientSideErrorError(error, ctx);
+      }
+      case "ValidationException": {
+        return serializeValidationExceptionError(error, ctx);
+      }
+      default: {
+        throw error;
+      }
+    }
+  }
+
+}
+
+export const getRefreshCachedDataHandler = <Context>(operation: __Operation<RefreshCachedDataServerInput, RefreshCachedDataServerOutput, Context>): __ServiceHandler<Context, __HttpRequest, __HttpResponse> => {
+  const mux = new httpbinding.HttpBindingMux<"AppFramework", "RefreshCachedData">([
+    new httpbinding.UriSpec<"AppFramework", "RefreshCachedData">(
+      'POST',
+      [
+        { type: 'path_literal', value: "installations" },
+        { type: 'path_literal', value: "refresh" },
+      ],
+      [
+      ],
+      { service: "AppFramework", operation: "RefreshCachedData" }),
+  ]);
+  const customizer: __ValidationCustomizer<"RefreshCachedData"> = (ctx, failures) => {
+    if (!failures) {
+      return undefined;
+    }
+    return {
+      name: "ValidationException",
+      $fault: "client",
+      message: __generateValidationSummary(failures),
+      fieldList: failures.map(failure => ({
+        path: failure.path,
+        message: __generateValidationMessage(failure)
+      }))
+    };
+  };
+  return new RefreshCachedDataHandler(operation, mux, new RefreshCachedDataSerializer(), serializeFrameworkException, customizer);
+}
+
+const serdeContextBase = {
+  base64Encoder: toBase64,
+  base64Decoder: fromBase64,
+  utf8Encoder: toUtf8,
+  utf8Decoder: fromUtf8,
+  streamCollector: streamCollector,
+  requestHandler: new NodeHttpHandler(),
+  disableHostPrefix: true
+};
+async function handle<S, O extends keyof S & string, Context>(
+  request: __HttpRequest,
+  context: Context,
+  operationName: O,
+  serializer: __OperationSerializer<S, O, __ServiceException>,
+  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
+  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
+  validationCustomizer: __ValidationCustomizer<O>
+): Promise<__HttpResponse> {
+  let input;
+  try {
+    input = await serializer.deserialize(request, {
+      endpoint: () => Promise.resolve(request), ...serdeContextBase
+    });
+  } catch (error: unknown) {
+    if (__isFrameworkException(error)) {
+      return serializeFrameworkException(error, serdeContextBase);
+    };
+    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
+  }
+  try {
+    let validationFailures = validationFn(input);
+    if (validationFailures && validationFailures.length > 0) {
+      let validationException = validationCustomizer({ operation: operationName }, validationFailures);
+      if (validationException) {
+        return serializer.serializeError(validationException, serdeContextBase);
+      }
+    }
+    let output = await operation(input, context);
+    return serializer.serialize(output, serdeContextBase);
+  } catch(error: unknown) {
+    if (serializer.isOperationError(error)) {
+      return serializer.serializeError(error, serdeContextBase);
+    }
+    console.log('Received an unexpected error', error);
+    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+  }
+}
+export class RefreshCachedDataHandler<Context> implements __ServiceHandler<Context> {
+  private readonly operation: __Operation<RefreshCachedDataServerInput, RefreshCachedDataServerOutput, Context>;
+  private readonly mux: __Mux<"AppFramework", "RefreshCachedData">;
+  private readonly serializer: __OperationSerializer<AppFrameworkService<Context>, "RefreshCachedData", RefreshCachedDataErrors>;
+  private readonly serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>;
+  private readonly validationCustomizer: __ValidationCustomizer<"RefreshCachedData">;
+  /**
+   * Construct a RefreshCachedData handler.
+   * @param operation The {@link __Operation} implementation that supplies the business logic for RefreshCachedData
+   * @param mux The {@link __Mux} that verifies which service and operation are being invoked by a given {@link __HttpRequest}
+   * @param serializer An {@link __OperationSerializer} for RefreshCachedData that
+   *                   handles deserialization of requests and serialization of responses
+   * @param serializeFrameworkException A function that can serialize {@link __SmithyFrameworkException}s
+   * @param validationCustomizer A {@link __ValidationCustomizer} for turning validation failures into {@link __SmithyFrameworkException}s
+   */
+  constructor(
+    operation: __Operation<RefreshCachedDataServerInput, RefreshCachedDataServerOutput, Context>,
+    mux: __Mux<"AppFramework", "RefreshCachedData">,
+    serializer: __OperationSerializer<AppFrameworkService<Context>, "RefreshCachedData", RefreshCachedDataErrors>,
+    serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+    validationCustomizer: __ValidationCustomizer<"RefreshCachedData">
+  ) {
+    this.operation = operation;
+    this.mux = mux;
+    this.serializer = serializer;
+    this.serializeFrameworkException = serializeFrameworkException;
+    this.validationCustomizer = validationCustomizer;
+  }
+  async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
+    const target = this.mux.match(request);
+    if (target === undefined) {
+      console.log('Received a request that did not match framework.api#AppFramework.RefreshCachedData. This indicates a misconfiguration.');
+      return this.serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+    }
+    return handle(request, context, "RefreshCachedData", this.serializer, this.operation, this.serializeFrameworkException, RefreshCachedDataServerInput.validate, this.validationCustomizer);
+  }
+}

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/server/operations/index.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/server/operations/index.ts
@@ -1,3 +1,5 @@
 // smithy-typescript generated code
 export * from "./GetAppToken";
+export * from "./GetInstallationData";
 export * from "./GetInstallationToken";
+export * from "./RefreshCachedData";

--- a/src/packages/smithy/model/credential_management.smithy
+++ b/src/packages/smithy/model/credential_management.smithy
@@ -2,7 +2,7 @@ $version: "2.0"
 namespace framework.api
 
 resource CredentialManagementService{
-    operations: [GetInstallationToken, GetAppToken]
+    operations: [GetInstallationToken, GetAppToken, RefreshCachedData, GetInstallationData]
 }
 
 // Placeholder API endpoints
@@ -19,6 +19,20 @@ operation GetAppToken {
     input: GetAppTokenInput,
     output: GetAppTokenOutput
     errors:[ServerSideError, ClientSideError]
+}
+
+@http(method: "POST", uri: "/installations/refresh")
+operation RefreshCachedData {
+    input: RefreshCachedDataInput,
+    output: RefreshCachedDataOutput,
+    errors: [ServerSideError, ClientSideError]
+}
+
+@http(method: "POST", uri: "/installations/info")
+operation GetInstallationData {
+    input: GetInstallationDataInput,
+    output: GetInstallationDataOutput,
+    errors: [ServerSideError, ClientSideError]
 }
 
 structure GetInstallationTokenInput {
@@ -50,6 +64,33 @@ structure GetAppTokenOutput {
     appId: Integer
     @timestampFormat("date-time")
     expirationTime: Timestamp
+}
+
+structure RefreshCachedDataInput {}
+
+structure RefreshCachedDataOutput {
+    message: String
+    @timestampFormat("date-time")
+    refreshedDate: Timestamp
+}
+
+structure GetInstallationDataInput {
+    @length(min: 1, max:256)
+    @required
+    nodeId: String
+}
+
+structure InstallationData {
+    nodeId: String
+    appId: Integer
+    installationId: Integer
+}
+
+list InstallationDataList {
+    member: InstallationData
+}
+structure GetInstallationDataOutput {
+    installations: InstallationDataList
 }
 
 @httpError(500)


### PR DESCRIPTION
To support multiple GitHub Apps, we need to build two new Genet APIs that allows customers to refresh cached installation data on demand. This is because users don’t know which GitHub App is installed on which organization, and the only way to find out is by querying the data from the Genet installation table. However, this table is updated by the installation tracker, which runs every 30 minutes, meaning users might have false negatives result within that time window. By exposing a refresh API, we can let users trigger an update whenever they need accurate data. The second API is for customer to query installations data. 

The PR added two new APIs into service smithy model and regenerated ssdk and client packages. 