### PR TITLE
Feat: add GitHub App installation refresh API

### DIFF
--- a/src/packages/app-framework/package.json
+++ b/src/packages/app-framework/package.json
@@ -68,7 +68,7 @@
     "@aws-sdk/util-dynamodb": "^3.777.0",
     "@aws-smithy/server-apigateway": "^1.0.0-alpha.10",
     "@aws-smithy/server-common": "^1.0.0-alpha.10",
-    "@aws/app-framework-for-github-apps-on-aws-ssdk": "^0.0.1",
+    "@aws/app-framework-for-github-apps-on-aws-ssdk": "^0.0.2",
     "@octokit/rest": "^21.1.1",
     "@octokit/types": "^14.0.0",
     "aws-lambda": "^1.0.7",

--- a/src/packages/app-framework/src/credential-manager/constants.ts
+++ b/src/packages/app-framework/src/credential-manager/constants.ts
@@ -12,6 +12,7 @@ export const TAG_VALUES = {
   ACTIVE: 'Active',
   APP_TOKEN_ENDPOINT: 'AppTokenEndpoint',
   INSTALLATION_ACCESS_TOKEN_ENDPOINT: 'InstallationAccessTokenEndpoint',
+  REFRESH_CACHED_DATA_ENDPOINT: 'RefreshCachedDataEndpoint',
 };
 
 export enum EnvironmentVariables {

--- a/src/packages/app-framework/src/credential-manager/refresh/index.handler.ts
+++ b/src/packages/app-framework/src/credential-manager/refresh/index.handler.ts
@@ -1,0 +1,105 @@
+import {
+  RefreshCachedDataInput,
+  RefreshCachedDataOutput,
+  getRefreshCachedDataHandler,
+} from '@aws/app-framework-for-github-apps-on-aws-ssdk';
+import {
+  convertEvent,
+  convertVersion1Response,
+} from '@aws-smithy/server-apigateway';
+import {
+  APIGatewayEventRequestContextIAMAuthorizer,
+  APIGatewayEventRequestContextV2WithAuthorizer,
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResultV2,
+} from 'aws-lambda';
+import { EnvironmentError } from '../../error';
+import { EnvironmentVariables } from '../constants';
+import { refreshCachedDataOperationImpl } from './refreshCachedDataOperation';
+
+/**
+ * Lambda entry point.
+ */
+export const handler = async (
+  event: APIGatewayProxyEventV2,
+): Promise<APIGatewayProxyResultV2> => {
+  const context =
+    event.requestContext as APIGatewayEventRequestContextV2WithAuthorizer<APIGatewayEventRequestContextIAMAuthorizer>;
+  const result: APIGatewayProxyResultV2 = await handlerImpl({ event });
+  const parseResponse = JSON.parse(JSON.stringify(result));
+  const bodyData = JSON.parse(parseResponse.body) as RefreshCachedDataOutput;
+  if (!!bodyData.message && !!bodyData.refreshedDate) {
+    const logResponse = {
+      caller: context.authorizer.iam.userArn,
+      message: bodyData.message,
+      refreshedDate: bodyData.refreshedDate,
+    };
+    console.log(JSON.stringify(logResponse));
+  }
+  return result;
+};
+
+export type Handler = ({
+  event,
+  checkEnvironment,
+  refreshCachedDataOperation,
+}: {
+  event: APIGatewayProxyEventV2;
+  checkEnvironment?: CheckEnvironment;
+  refreshCachedDataOperation?: (
+    input: RefreshCachedDataInput,
+    _context: { appTable: string; installationTable: string },
+  ) => Promise<RefreshCachedDataOutput>;
+}) => Promise<APIGatewayProxyResultV2>;
+
+/**
+ * Core Lambda handler logic for processing refreshing Installation cached data request.
+ *
+ * @param event Lambda event from Lambda Function URL.
+ * @param checkEnvironment Checking environment config for appTable and installationTable.
+ * @param refreshCachedDataOperation Operation for refreshing installation cached data.
+ */
+export const handlerImpl: Handler = async ({
+  event,
+  checkEnvironment = checkEnvironmentImpl,
+  refreshCachedDataOperation = refreshCachedDataOperationImpl,
+}) => {
+  console.log('Event received', event);
+  const context = checkEnvironment();
+  const httpRequest = convertEvent(event);
+  console.log('Smithy event:', httpRequest);
+  const refreshCachedDataHandler = getRefreshCachedDataHandler(
+    refreshCachedDataOperation,
+  );
+  const result = await refreshCachedDataHandler.handle(httpRequest, context);
+  return convertVersion1Response(result);
+};
+/**
+ *  Retrieves Installations Table and App Table names
+ *
+ ---
+ @returns An Installations Table and App Table names
+ @throws EnvironmentError if Installations Table or App Table names are not present
+ */
+type CheckEnvironment = () => {
+  appTable: string;
+  installationTable: string;
+};
+const checkEnvironmentImpl: CheckEnvironment = () => {
+  const appTable = process.env.APP_TABLE_NAME;
+  if (!appTable) {
+    throw new EnvironmentError(
+      `No value found in ${EnvironmentVariables.APP_TABLE_NAME} environment variable.`,
+    );
+  }
+  const installationTable = process.env.INSTALLATION_TABLE_NAME;
+  if (!installationTable) {
+    throw new EnvironmentError(
+      `No value found in ${EnvironmentVariables.INSTALLATION_TABLE_NAME} environment variable.`,
+    );
+  }
+  return {
+    appTable,
+    installationTable,
+  };
+};

--- a/src/packages/app-framework/src/credential-manager/refresh/index.ts
+++ b/src/packages/app-framework/src/credential-manager/refresh/index.ts
@@ -1,0 +1,83 @@
+import { Stack, Tags } from 'aws-cdk-lib';
+import { ITable } from 'aws-cdk-lib/aws-dynamodb';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import {
+  FunctionUrlAuthType,
+  HttpMethod,
+  IFunctionUrl,
+} from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+import { LAMBDA_DEFAULTS } from '../../lambdaDefaults';
+import { EnvironmentVariables, TAG_KEYS, TAG_VALUES } from '../constants';
+
+export interface InstallationRefreshProps {
+  readonly AppTable: ITable;
+  readonly InstallationTable: ITable;
+}
+
+export class InstallationRefresher extends Construct {
+  readonly lambdaHandler: NodejsFunction;
+  readonly functionUrl: IFunctionUrl;
+  constructor(scope: Construct, id: string, props: InstallationRefreshProps) {
+    super(scope, id);
+
+    this.lambdaHandler = new NodejsFunction(this, 'handler', {
+      ...LAMBDA_DEFAULTS,
+      bundling: {
+        ...LAMBDA_DEFAULTS.bundling,
+        nodeModules: ['re2-wasm'],
+      },
+      environment: {
+        [EnvironmentVariables.APP_TABLE_NAME]: props.AppTable.tableName,
+        [EnvironmentVariables.INSTALLATION_TABLE_NAME]:
+          props.InstallationTable.tableName,
+      },
+      description: 'Refresh app installations',
+      memorySize: 512,
+    });
+    this.functionUrl = this.lambdaHandler.addFunctionUrl({
+      authType: FunctionUrlAuthType.AWS_IAM,
+      cors: {
+        allowedOrigins: ['*'],
+        allowedMethods: [HttpMethod.POST],
+        allowedHeaders: ['*'],
+      },
+    });
+
+    Tags.of(this.functionUrl).add(
+      TAG_KEYS.CREDENTIAL_MANAGER,
+      TAG_VALUES.REFRESH_CACHED_DATA_ENDPOINT,
+    );
+
+    this.lambdaHandler.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          'dynamodb:Scan',
+          'dynamodb:GetItem',
+          'dynamodb:PutItem',
+          'dynamodb:DeleteItem',
+        ],
+        resources: [props.AppTable.tableArn, props.InstallationTable.tableArn],
+      }),
+    );
+
+    this.lambdaHandler.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['kms:Sign'],
+        resources: [
+          `arn:aws:kms:${Stack.of(this).region}:${Stack.of(this).account}:key/*`,
+        ],
+        conditions: {
+          StringEquals: {
+            [`aws:ResourceTag/${TAG_KEYS.FRAMEWORK_FOR_GITHUB_APP_ON_AWS_MANAGED}`]:
+              TAG_VALUES.TRUE,
+            [`aws:ResourceTag/${TAG_KEYS.STATUS}`]: TAG_VALUES.ACTIVE,
+          },
+        },
+      }),
+    );
+  }
+}

--- a/src/packages/app-framework/src/credential-manager/refresh/refreshCachedData.ts
+++ b/src/packages/app-framework/src/credential-manager/refresh/refreshCachedData.ts
@@ -1,0 +1,123 @@
+import { RefreshCachedDataOutput } from '@aws/app-framework-for-github-apps-on-aws-ssdk';
+import {
+  getAppIdsImpl,
+  getMappedInstallationIdsImpl,
+  InstallationRecord,
+  PutInstallation,
+  putInstallationImpl,
+  GetAppIds,
+  GetMappedInstallations,
+} from '../../data';
+import { ServerError } from '../../error';
+import { GitHubAPIService } from '../../gitHubService';
+import { GetAppToken, getAppTokenImpl } from '../get-app-token/getAppToken';
+import {
+  calculateInstallationDifferencesImpl,
+  CalculateInstallationDifferences,
+} from '../installation-tracker/index.handler';
+
+export type RefreshCachedData = ({
+  appTable,
+  installationTable,
+  getAppIds,
+  getMappedInstallationIds,
+  getAppToken,
+  calculateInstallationDifferences,
+  putInstallation,
+}: {
+  appTable: string;
+  installationTable: string;
+  getAppIds?: GetAppIds;
+  getMappedInstallationIds?: GetMappedInstallations;
+  getAppToken?: GetAppToken;
+  calculateInstallationDifferences?: CalculateInstallationDifferences;
+  putInstallation?: PutInstallation;
+}) => Promise<RefreshCachedDataOutput>;
+/**
+ * Syncs installation data between GitHub and DynamoDB.
+ * Retrieves all App IDs from the App Table, fetches current installations from GitHub, and updates
+ * the Installation Table with a refreshed timestamp. It also identifies:
+ * - Unverified installations: in GitHub but missing in DynamoDB
+ * - Missing installations: in DynamoDB but not found in GitHub
+ * @param appTable - Name of the DynamoDB table storing GitHub App metadata
+ * @param installationTable - Name of the DynamoDB table storing installation metadata
+ * @param getAppIds - Function for fetching App IDs
+ * @param getMappedInstallationIds - Function for retrieving registered installations
+ * @param getAppToken - Function for retrieving GitHub App tokens
+ * @param calculateInstallationDifferences - Function for computing discrepancies
+ * @param putInstallation - Function for writing installation records
+ * @returns A message confirming sync and the timestamp of the refresh
+ * @throws ServerError if any error detected
+ */
+export const refreshCachedDataImpl: RefreshCachedData = async ({
+  appTable,
+  installationTable,
+  getAppIds = getAppIdsImpl,
+  getMappedInstallationIds = getMappedInstallationIdsImpl,
+  getAppToken = getAppTokenImpl,
+  calculateInstallationDifferences = calculateInstallationDifferencesImpl,
+  putInstallation = putInstallationImpl,
+}): Promise<RefreshCachedDataOutput> => {
+  try {
+    // Find all AppIds for this account.
+    const appIds: number[] = await getAppIds({ tableName: appTable });
+
+    // Find all installations for this account, split by AppId.
+    // Registered installations are known in DynamoDB.
+    const registeredInstallations = await getMappedInstallationIds({
+      tableName: installationTable,
+    });
+    // GitHub installations are actual installations that GitHub has.
+    const githubConfirmedInstallations: Record<number, InstallationRecord[]> =
+      {};
+    // Find all installations for this account, according to GitHub.
+    await Promise.all(
+      appIds.map(async (appId) => {
+        // Fetch each AppToken for this account.
+        const appToken = (await getAppToken({ appId, tableName: appTable }))
+          .appToken;
+        // Using the App identity granted by the AppToken, generate a GitHub client.
+        const githubService = new GitHubAPIService({ token: appToken });
+        // Fetch installations from GitHub and map them to the fields we need.
+        const actualInstallations = await githubService.getInstallations({});
+        const gitHubInstallations: InstallationRecord[] = await Promise.all(
+          actualInstallations.map((installation) => {
+            return {
+              installationId: installation.id,
+              appId: appId,
+              nodeId: installation.account ? installation.account.node_id : '',
+            };
+          }),
+        );
+        githubConfirmedInstallations[appId] = gitHubInstallations;
+        // Update last refreshed timestamp to all items.
+        await Promise.all(
+          gitHubInstallations.map(async (installation) => {
+            await putInstallation({
+              tableName: installationTable,
+              ...installation,
+              lastRefreshed: new Date().toISOString(),
+            });
+          }),
+        );
+      }),
+    );
+    // Calculate where GitHub has more installations than we have registered,
+    // or where Dynamo has installations GitHub doesn't know about.
+    const { unverifiedInstallations, missingInstallations } =
+      await calculateInstallationDifferences({
+        appIds,
+        githubConfirmedInstallations,
+        registeredInstallations,
+      });
+    console.log('Updated:', unverifiedInstallations);
+    console.log('Deleted:', missingInstallations);
+    return {
+      message: 'Installation sync completed.',
+      refreshedDate: new Date(),
+    };
+  } catch (error: any) {
+    console.error('Installation sync failed:', error);
+    throw new ServerError(error.message);
+  }
+};

--- a/src/packages/app-framework/src/credential-manager/refresh/refreshCachedDataOperation.ts
+++ b/src/packages/app-framework/src/credential-manager/refresh/refreshCachedDataOperation.ts
@@ -1,0 +1,31 @@
+import {
+  ServerSideError,
+  RefreshCachedDataInput,
+  RefreshCachedDataOutput,
+} from '@aws/app-framework-for-github-apps-on-aws-ssdk';
+import { Operation } from '@aws-smithy/server-common';
+import { refreshCachedDataImpl } from './refreshCachedData';
+
+/**
+ *  Smithy operation that refresh GitHub App installations cached data.
+ *  --
+ *  @param _input
+ *  @param context contains the name of appTable and installationTable
+ *  @returns A message shows the sync up successfully.
+ */
+export const refreshCachedDataOperationImpl: Operation<
+  RefreshCachedDataInput,
+  RefreshCachedDataOutput,
+  { appTable: string; installationTable: string }
+> = async (_input, context) => {
+  try {
+    const result = await refreshCachedDataImpl({
+      appTable: context.appTable,
+      installationTable: context.installationTable,
+    });
+    return result;
+  } catch (error) {
+    console.error(error);
+    throw new ServerSideError({ message: 'Internal Server Error' });
+  }
+};

--- a/src/packages/app-framework/src/data.ts
+++ b/src/packages/app-framework/src/data.ts
@@ -115,11 +115,13 @@ export type PutInstallation = ({
   appId,
   nodeId,
   installationId,
+  lastRefreshed,
 }: {
   tableName: string;
   appId: number;
   nodeId: string;
   installationId: number;
+  lastRefreshed?: string;
 }) => Promise<void>;
 
 export const putInstallationImpl: PutInstallation = async ({
@@ -127,6 +129,7 @@ export const putInstallationImpl: PutInstallation = async ({
   appId,
   nodeId,
   installationId,
+  lastRefreshed,
 }): Promise<void> => {
   const tableOperations = new TableOperations({
     TableName: tableName,
@@ -136,6 +139,7 @@ export const putInstallationImpl: PutInstallation = async ({
     AppId: { N: appId.toString() },
     NodeId: { S: nodeId },
     InstallationId: { N: installationId.toString() },
+    LastRefreshed: { S: lastRefreshed || '' },
   };
 
   await tableOperations.putItem(item);

--- a/src/packages/app-framework/test/data.test.ts
+++ b/src/packages/app-framework/test/data.test.ts
@@ -231,6 +231,7 @@ describe('getInstallationId', () => {
       expect(mockTableOperations.prototype.putItem).toHaveBeenCalledWith({
         AppId: { N: mockAppId.toString() },
         InstallationId: { N: mockInstallationId.toString() },
+        LastRefreshed: { S: '' },
         NodeId: { S: mockNodeId },
       });
     });
@@ -243,6 +244,7 @@ describe('getInstallationId', () => {
         putInstallationImpl({
           tableName: mockTableName,
           appId: mockAppId,
+          lastRefreshed: '',
           installationId: mockInstallationId,
           nodeId: mockNodeId,
         }),

--- a/src/packages/app-framework/test/installation-tracker/index.handler.test.ts
+++ b/src/packages/app-framework/test/installation-tracker/index.handler.test.ts
@@ -37,6 +37,7 @@ beforeEach(() => {
 
 describe('handlerImpl', () => {
   it('Returns unverified and missing installations list in API Gateway Proxy event when there are both missing and unverified installations', async () => {
+    const putInstallationMock = jest.fn().mockResolvedValue(undefined);
     const mockSuccessResponse = [
       {
         id: 3,
@@ -60,6 +61,7 @@ describe('handlerImpl', () => {
           { appId: 3, installationId: 21, nodeId: 'baz' },
         ],
       }),
+      putInstallation: putInstallationMock,
     });
     expect(result).toEqual({
       body: JSON.stringify({
@@ -70,6 +72,15 @@ describe('handlerImpl', () => {
       }),
       statusCode: 200,
     });
+    expect(putInstallationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 3,
+        installationId: 3,
+        nodeId: 'baz',
+        tableName: expect.any(String),
+        lastRefreshed: expect.any(String),
+      }),
+    );
   });
   it('Throws an error when running into errors', async () => {
     mockGetInstallations.mockRejectedValue(

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,10 +991,10 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@aws/app-framework-for-github-apps-on-aws-ssdk@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@aws/app-framework-for-github-apps-on-aws-ssdk/-/app-framework-for-github-apps-on-aws-ssdk-0.0.1.tgz#4346bf1edcd972433736ec1d4fefac73ee716c92"
-  integrity sha512-tOgNmXBtp7PemkMktOJCacSVqQGb1k3hX2+staVPdXWm0ZuDcKV1Tf1L0/89u5zekpyav37g45xW2xm7X3E5Rg==
+"@aws/app-framework-for-github-apps-on-aws-ssdk@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@aws/app-framework-for-github-apps-on-aws-ssdk/-/app-framework-for-github-apps-on-aws-ssdk-0.0.2.tgz#59c55bab1056af21debad50af3aba1e1bf4ae869"
+  integrity sha512-Lrh/UNB36MzNFuqfkY4+buLQmysPYZck845FXKcGFmXf6xK4be8bx/AjQcFju+pTh4AiAd9rqzSr+VPCKlG9cQ==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"


### PR DESCRIPTION
Feat #
To support multiple GitHub Apps, we need to build new Genet APIs that allows customers to refresh cached installation data on demand. This is because users don’t know which GitHub App is installed on which organization, and the only way to find out is by querying the data from the Genet installation table. However, this table is updated by the installation tracker, which runs every 30 minutes, meaning users might have false negatives result within that time window. By exposing a refresh API, we can let users trigger an update whenever they need accurate data.

Once the API is called, it will update all item with latest timestamp. 