### PR TITLE
chore: add back ratelimittracker unit test case

### DIFF
--- a/src/packages/app-framework-ops-tools/README.md
+++ b/src/packages/app-framework-ops-tools/README.md
@@ -153,7 +153,7 @@ The app-framework CLI tool is built using Node.js and TypeScript. To use it:
 1. Install the package:
 
 ```sh
-npm install @aws/app-framework-for-github-apps-on-aws-ops-tools
+npm install -g @aws/app-framework-for-github-apps-on-aws-ops-tools
 ```
 
 1. The CLI tool will be available through:

--- a/src/packages/app-framework/test/rate-limit-tracker/index.handler.test.ts
+++ b/src/packages/app-framework/test/rate-limit-tracker/index.handler.test.ts
@@ -39,42 +39,42 @@ describe('handlerImpl', () => {
     Metrics.prototype,
     'publishStoredMetrics',
   );
-  // it('Publish metrics three times due to three different rate limits present in GitHub output', async () => {
-  //   const rate_limit_response = {
-  //     resources: {
-  //       core: {
-  //         limit: 5000,
-  //         used: 1,
-  //         remaining: 4999,
-  //         reset: 1691591363,
-  //       },
-  //       search: {
-  //         limit: 30,
-  //         used: 12,
-  //         remaining: 18,
-  //         reset: 1691591091,
-  //       },
-  //       rate: {
-  //         limit: 5000,
-  //         used: 1,
-  //         remaining: 4999,
-  //         reset: 1372700873,
-  //       },
-  //     },
-  //   };
-  //   mockGetRateLimit.mockReturnValue(rate_limit_response);
-  //   await handlerImpl({
-  //     getInstallationsFromTable: jest
-  //       .fn()
-  //       .mockReturnValue([{ appId: 1, installationId: 20, nodeId: 'foo' }]),
-  //     getInstallationAccessToken: jest
-  //       .fn()
-  //       .mockReturnValue({ installationToken: 'some-token' }),
-  //   });
-  //   expect(addDimensionSpy).toHaveBeenCalledTimes(9);
-  //   expect(addMetricSpy).toHaveBeenCalledTimes(15);
-  //   expect(publishStoredMetricsSpy).toHaveBeenCalledTimes(3);
-  // });
+  it('Publish metrics three times due to three different rate limits present in GitHub output', async () => {
+    const rate_limit_response = {
+      resources: {
+        core: {
+          limit: 5000,
+          used: 1,
+          remaining: 4999,
+          reset: 1691591363,
+        },
+        search: {
+          limit: 30,
+          used: 12,
+          remaining: 18,
+          reset: 1691591091,
+        },
+        rate: {
+          limit: 5000,
+          used: 1,
+          remaining: 4999,
+          reset: 1372700873,
+        },
+      },
+    };
+    mockGetRateLimit.mockReturnValue(rate_limit_response);
+    await handlerImpl({
+      getInstallationsFromTable: jest
+        .fn()
+        .mockReturnValue([{ appId: 1, installationId: 20, nodeId: 'foo' }]),
+      getInstallationAccessToken: jest
+        .fn()
+        .mockReturnValue({ installationToken: 'some-token' }),
+    });
+    expect(addDimensionSpy).toHaveBeenCalledTimes(9);
+    expect(addMetricSpy).toHaveBeenCalledTimes(15);
+    expect(publishStoredMetricsSpy).toHaveBeenCalledTimes(3);
+  });
   it('No metrics are published when rate limit API throws error', async () => {
     mockGetRateLimit.mockRejectedValue(
       new GitHubError(


### PR DESCRIPTION
Fixes #
- Add back failed rate-limit-tracker test case that is now working fine
- Modified ops-tools installation command to global installation command