### PR TITLE
feat: add requested and actual scopeDown to GetInstallationTokenOutput smithy model

### DIFF
--- a/src/packages/smithy/build/smithy/source/model/model.json
+++ b/src/packages/smithy/build/smithy/source/model/model.json
@@ -2066,6 +2066,12 @@
                     "traits": {
                         "smithy.api#timestampFormat": "date-time"
                     }
+                },
+                "requestedScopeDown": {
+                    "target": "framework.api#ScopeDown"
+                },
+                "actualScopeDown": {
+                    "target": "framework.api#ScopeDown"
                 }
             }
         },

--- a/src/packages/smithy/build/smithy/source/sources/credential_management.smithy
+++ b/src/packages/smithy/build/smithy/source/sources/credential_management.smithy
@@ -71,6 +71,8 @@ structure GetInstallationTokenOutput {
     appId: Integer
     @timestampFormat("date-time")
     expirationTime: Timestamp
+    requestedScopeDown: ScopeDown
+    actualScopeDown: ScopeDown
 }
 
 structure GetAppTokenInput {

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/GetInstallationTokenCommand.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/commands/GetInstallationTokenCommand.ts
@@ -66,6 +66,28 @@ export interface GetInstallationTokenCommandOutput extends GetInstallationTokenO
  * //   nodeId: "STRING_VALUE",
  * //   appId: Number("int"),
  * //   expirationTime: new Date("TIMESTAMP"),
+ * //   requestedScopeDown: { // ScopeDown
+ * //     repositoryIds: [ // RepositoryIds
+ * //       Number("int"),
+ * //     ],
+ * //     repositoryNames: [ // RepositoryNames
+ * //       "STRING_VALUE",
+ * //     ],
+ * //     permissions: { // Permissions
+ * //       "<keys>": "STRING_VALUE",
+ * //     },
+ * //   },
+ * //   actualScopeDown: {
+ * //     repositoryIds: [
+ * //       Number("int"),
+ * //     ],
+ * //     repositoryNames: [
+ * //       "STRING_VALUE",
+ * //     ],
+ * //     permissions: {
+ * //       "<keys>": "STRING_VALUE",
+ * //     },
+ * //   },
  * // };
  *
  * ```

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/models/models_0.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/models/models_0.ts
@@ -154,6 +154,8 @@ export interface GetInstallationTokenOutput {
   nodeId?: string | undefined;
   appId?: number | undefined;
   expirationTime?: Date | undefined;
+  requestedScopeDown?: ScopeDown | undefined;
+  actualScopeDown?: ScopeDown | undefined;
 }
 
 /**

--- a/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/protocols/Aws_restJson1.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-client-codegen/src/protocols/Aws_restJson1.ts
@@ -197,10 +197,12 @@ export const de_GetInstallationTokenCommand = async(
   });
   const data: Record<string, any> = __expectNonNull((__expectObject(await parseBody(output.body, context))), "body");
   const doc = take(data, {
+    'actualScopeDown': _json,
     'appId': __expectInt32,
     'expirationTime': _ => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
     'installationToken': __expectString,
     'nodeId': __expectString,
+    'requestedScopeDown': _json,
   });
   Object.assign(contents, doc);
   return contents;
@@ -336,6 +338,14 @@ const de_CommandError = async(
   // de_InstallationData omitted.
 
   // de_InstallationDataList omitted.
+
+  // de_Permissions omitted.
+
+  // de_RepositoryIds omitted.
+
+  // de_RepositoryNames omitted.
+
+  // de_ScopeDown omitted.
 
   // de_ValidationExceptionField omitted.
 

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/models/models_0.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/models/models_0.ts
@@ -446,6 +446,8 @@ export interface GetInstallationTokenOutput {
   nodeId?: string | undefined;
   appId?: number | undefined;
   expirationTime?: Date | undefined;
+  requestedScopeDown?: ScopeDown | undefined;
+  actualScopeDown?: ScopeDown | undefined;
 }
 
 export namespace GetInstallationTokenOutput {
@@ -454,6 +456,8 @@ export namespace GetInstallationTokenOutput {
     nodeId?: __MultiConstraintValidator<string>,
     appId?: __MultiConstraintValidator<number>,
     expirationTime?: __MultiConstraintValidator<Date>,
+    requestedScopeDown?: __MultiConstraintValidator<ScopeDown>,
+    actualScopeDown?: __MultiConstraintValidator<ScopeDown>,
   } = {};
   /**
    * @internal
@@ -478,6 +482,20 @@ export namespace GetInstallationTokenOutput {
             memberValidators["expirationTime"] = new __NoOpValidator();
             break;
           }
+          case "requestedScopeDown": {
+            memberValidators["requestedScopeDown"] = new __CompositeStructureValidator<ScopeDown>(
+              new __NoOpValidator(),
+              ScopeDown.validate
+            );
+            break;
+          }
+          case "actualScopeDown": {
+            memberValidators["actualScopeDown"] = new __CompositeStructureValidator<ScopeDown>(
+              new __NoOpValidator(),
+              ScopeDown.validate
+            );
+            break;
+          }
         }
       }
       return memberValidators[member]!!;
@@ -487,6 +505,8 @@ export namespace GetInstallationTokenOutput {
       ...getMemberValidator("nodeId").validate(obj.nodeId, `${path}/nodeId`),
       ...getMemberValidator("appId").validate(obj.appId, `${path}/appId`),
       ...getMemberValidator("expirationTime").validate(obj.expirationTime, `${path}/expirationTime`),
+      ...getMemberValidator("requestedScopeDown").validate(obj.requestedScopeDown, `${path}/requestedScopeDown`),
+      ...getMemberValidator("actualScopeDown").validate(obj.actualScopeDown, `${path}/actualScopeDown`),
     ];
   }
 }

--- a/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/protocols/Aws_restJson1.ts
+++ b/src/packages/smithy/build/smithy/source/typescript-ssdk-codegen/src/protocols/Aws_restJson1.ts
@@ -256,10 +256,12 @@ export const serializeGetInstallationTokenResponse = async(
   });
   let body: any;
   body = JSON.stringify(take(input, {
+    'actualScopeDown': _ => se_ScopeDown(_, context),
     'appId': [],
     'expirationTime': _ => __serializeDateTime(_),
     'installationToken': [],
     'nodeId': [],
+    'requestedScopeDown': _ => se_ScopeDown(_, context),
   }));
   if (body && Object.keys(headers).map((str) => str.toLowerCase()).indexOf('content-length') === -1) {
     const length = calculateBodyLength(body);
@@ -502,6 +504,56 @@ const se_InstallationDataList = (
 ): any => {
   return input.filter((e: any) => e != null).map(entry => {
     return se_InstallationData(entry, context);
+  });
+}
+
+/**
+ * serializeAws_restJson1Permissions
+ */
+const se_Permissions = (
+  input: Record<string, string>,
+  context: __SerdeContext
+): any => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    acc[key] = value;
+    return acc;
+  }, {});
+}
+
+/**
+ * serializeAws_restJson1RepositoryIds
+ */
+const se_RepositoryIds = (
+  input: (number)[],
+  context: __SerdeContext
+): any => {
+  return input.filter((e: any) => e != null);
+}
+
+/**
+ * serializeAws_restJson1RepositoryNames
+ */
+const se_RepositoryNames = (
+  input: (string)[],
+  context: __SerdeContext
+): any => {
+  return input.filter((e: any) => e != null);
+}
+
+/**
+ * serializeAws_restJson1ScopeDown
+ */
+const se_ScopeDown = (
+  input: ScopeDown,
+  context: __SerdeContext
+): any => {
+  return take(input, {
+    'permissions': _ => se_Permissions(_, context),
+    'repositoryIds': _ => se_RepositoryIds(_, context),
+    'repositoryNames': _ => se_RepositoryNames(_, context),
   });
 }
 

--- a/src/packages/smithy/model/credential_management.smithy
+++ b/src/packages/smithy/model/credential_management.smithy
@@ -71,6 +71,8 @@ structure GetInstallationTokenOutput {
     appId: Integer
     @timestampFormat("date-time")
     expirationTime: Timestamp
+    requestedScopeDown: ScopeDown
+    actualScopeDown: ScopeDown
 }
 
 structure GetAppTokenInput {


### PR DESCRIPTION
Added two fields to `GetInstallationTokenOutput`
- `requestedScopeDown` - Shows the scope down permissons requested by the user
- `actualScopeDown` - Shows the scope down permissions granted by GitHub