### PR TITLE
feat: Adding TargetType field to installations table

### DIFF
--- a/src/packages/app-framework/src/credential-manager/installation-tracker/index.handler.ts
+++ b/src/packages/app-framework/src/credential-manager/installation-tracker/index.handler.ts
@@ -103,6 +103,7 @@ export const handlerImpl: Handler = async ({
             installationId: installation.id,
             appId: appId,
             nodeId: installation.account ? installation.account.node_id : '',
+            targetType: installation.target_type,
           };
         }),
       );

--- a/src/packages/app-framework/src/credential-manager/refresh/refreshCachedData.ts
+++ b/src/packages/app-framework/src/credential-manager/refresh/refreshCachedData.ts
@@ -86,6 +86,7 @@ export const refreshCachedDataImpl: RefreshCachedData = async ({
               installationId: installation.id,
               appId: appId,
               nodeId: installation.account ? installation.account.node_id : '',
+              targetType: installation.target_type,
             };
           }),
         );

--- a/src/packages/app-framework/src/data.ts
+++ b/src/packages/app-framework/src/data.ts
@@ -13,6 +13,7 @@ export type InstallationRecord = {
   appId: number;
   installationId: number;
   nodeId: string;
+  targetType: string;
 };
 
 type AppInstallations = {
@@ -115,12 +116,14 @@ export type PutInstallation = ({
   appId,
   nodeId,
   installationId,
+  targetType,
   lastRefreshed,
 }: {
   tableName: string;
   appId: number;
   nodeId: string;
   installationId: number;
+  targetType: string;
   lastRefreshed?: string;
 }) => Promise<void>;
 
@@ -129,6 +132,7 @@ export const putInstallationImpl: PutInstallation = async ({
   appId,
   nodeId,
   installationId,
+  targetType,
   lastRefreshed,
 }): Promise<void> => {
   const tableOperations = new TableOperations({
@@ -139,6 +143,7 @@ export const putInstallationImpl: PutInstallation = async ({
     AppId: { N: appId.toString() },
     NodeId: { S: nodeId },
     InstallationId: { N: installationId.toString() },
+    TargetType: { S: targetType },
     LastRefreshed: { S: lastRefreshed || '' },
   };
 
@@ -241,11 +246,13 @@ export const getInstallationsImpl: GetInstallations = async ({ tableName }) => {
   itemList.map((item) => {
     const appId: number = item.AppId;
     const installationId: number = item.InstallationId;
+    const targetType: string = item.targetType;
     const nodeId: string = item.NodeId ?? '';
     result.push({
       appId,
       nodeId,
       installationId,
+      targetType,
     });
   });
   return result;
@@ -278,10 +285,12 @@ export const getInstallationsDataByNodeId: GetInstallationsByNodeId = async ({
     const appId: number = item.AppId;
     const itemNodeId: string = item.NodeId;
     const installationId: number = item.InstallationId;
+    const targetType: string = item.targetType;
     result.push({
       appId,
       nodeId: itemNodeId,
       installationId,
+      targetType,
     });
   });
 

--- a/src/packages/app-framework/test/data.test.ts
+++ b/src/packages/app-framework/test/data.test.ts
@@ -24,6 +24,7 @@ const mockAppId = 12345;
 const mockTableName = 'validAppTableName';
 const mockNodeId = 'foo';
 const mockInstallationId = 123456;
+const mockTargetType = 'Organization';
 const mockArn = 'arn:aws:kms:region:account:key/mock-key-id';
 describe('getKeyArnByID', () => {
   it('should successfully retrieve KMS ARN from DynamoDB', async () => {
@@ -224,6 +225,7 @@ describe('getInstallationId', () => {
         appId: mockAppId,
         installationId: mockInstallationId,
         nodeId: mockNodeId,
+        targetType: mockTargetType,
       });
 
       expect(TableOperations).toHaveBeenCalledWith({
@@ -234,6 +236,7 @@ describe('getInstallationId', () => {
         InstallationId: { N: mockInstallationId.toString() },
         LastRefreshed: { S: '' },
         NodeId: { S: mockNodeId },
+        TargetType: { S: mockTargetType },
       });
     });
 
@@ -248,6 +251,7 @@ describe('getInstallationId', () => {
           lastRefreshed: '',
           installationId: mockInstallationId,
           nodeId: mockNodeId,
+          targetType: mockTargetType,
         }),
       ).rejects.toThrow('DynamoDB service error');
     });

--- a/src/packages/app-framework/test/get-installation-data/getInstallationData.test.ts
+++ b/src/packages/app-framework/test/get-installation-data/getInstallationData.test.ts
@@ -14,11 +14,13 @@ describe('getInstallationsDataImpl', () => {
       appId: 12345,
       installationId: 67890,
       nodeId: mockNodeId,
+      targetType: 'Organization',
     },
     {
       appId: 54321,
       installationId: 98765,
       nodeId: mockNodeId,
+      targetType: 'Organization',
     },
   ];
 
@@ -94,16 +96,19 @@ describe('getInstallationsDataImpl', () => {
         appId: 12345,
         installationId: 67890,
         nodeId: mockNodeId,
+        targetType: 'Organization',
       },
       {
         appId: 54321,
         installationId: 98765,
         nodeId: mockNodeId,
+        targetType: 'Organization',
       },
       {
         appId: 11111,
         installationId: 22222,
         nodeId: mockNodeId,
+        targetType: 'Organization',
       },
     ];
     const mockGetInstallationsDataByNodeId = jest

--- a/src/packages/app-framework/test/installation-tracker/index.handler.test.ts
+++ b/src/packages/app-framework/test/installation-tracker/index.handler.test.ts
@@ -116,7 +116,14 @@ describe('calculateInstallationDifferencesImpl', () => {
     const result = await calculateInstallationDifferencesImpl({
       appIds: [1],
       githubConfirmedInstallations: {
-        1: [{ appId: 1, installationId: 20, nodeId: 'foo' }],
+        1: [
+          {
+            appId: 1,
+            installationId: 20,
+            nodeId: 'foo',
+            targetType: 'Organization',
+          },
+        ],
       },
       registeredInstallations: [],
       getMissingInstallations: jest.fn(),
@@ -136,7 +143,14 @@ describe('calculateInstallationDifferencesImpl', () => {
       appIds: [1],
       githubConfirmedInstallations: {},
       registeredInstallations: {
-        1: [{ appId: 1, installationId: 20, nodeId: 'foo' }],
+        1: [
+          {
+            appId: 1,
+            installationId: 20,
+            nodeId: 'foo',
+            targetType: 'Organization',
+          },
+        ],
       },
       getMissingInstallations: jest
         .fn()
@@ -152,10 +166,24 @@ describe('calculateInstallationDifferencesImpl', () => {
     const result = await calculateInstallationDifferencesImpl({
       appIds: [1, 3],
       githubConfirmedInstallations: {
-        3: [{ appId: 3, installationId: 21, nodeId: 'baz' }],
+        3: [
+          {
+            appId: 3,
+            installationId: 21,
+            nodeId: 'baz',
+            targetType: 'Organization',
+          },
+        ],
       },
       registeredInstallations: {
-        1: [{ appId: 1, installationId: 20, nodeId: 'foo' }],
+        1: [
+          {
+            appId: 1,
+            installationId: 20,
+            nodeId: 'foo',
+            targetType: 'Organization',
+          },
+        ],
       },
       getMissingInstallations: jest
         .fn()
@@ -184,7 +212,12 @@ describe('getUnverifiedInstallationsImpl', () => {
   it('Should return empty list if github installations is empty', async () => {
     const result = await getUnverifiedInstallationsImpl({
       registeredInstallationsForAppId: [
-        { appId: 1, installationId: 20, nodeId: 'foo' },
+        {
+          appId: 1,
+          installationId: 20,
+          nodeId: 'foo',
+          targetType: 'Organization',
+        },
       ],
       gitHubInstallationsForAppId: [],
       putInstallation,
@@ -196,29 +229,76 @@ describe('getUnverifiedInstallationsImpl', () => {
     const result = await getUnverifiedInstallationsImpl({
       registeredInstallationsForAppId: [],
       gitHubInstallationsForAppId: [
-        { appId: 1, installationId: 20, nodeId: 'foo' },
+        {
+          appId: 1,
+          installationId: 20,
+          nodeId: 'foo',
+          targetType: 'Organization',
+        },
       ],
       putInstallation,
     });
-    expect(result).toEqual([{ appId: 1, installationId: 20, nodeId: 'foo' }]);
+    expect(result).toEqual([
+      {
+        appId: 1,
+        installationId: 20,
+        nodeId: 'foo',
+        targetType: 'Organization',
+      },
+    ]);
     expect(putInstallation).toHaveBeenCalledTimes(1);
   });
   it('Should return github installations which are not present in registered installations', async () => {
     const result = await getUnverifiedInstallationsImpl({
       registeredInstallationsForAppId: [
-        { appId: 1, installationId: 20, nodeId: 'foo' },
-        { appId: 2, installationId: 21, nodeId: 'baz' },
+        {
+          appId: 1,
+          installationId: 20,
+          nodeId: 'foo',
+          targetType: 'Organization',
+        },
+        {
+          appId: 2,
+          installationId: 21,
+          nodeId: 'baz',
+          targetType: 'Organization',
+        },
       ],
       gitHubInstallationsForAppId: [
-        { appId: 1, installationId: 20, nodeId: 'foo' },
-        { appId: 3, installationId: 22, nodeId: 'bar' },
-        { appId: 4, installationId: 23, nodeId: 'random' },
+        {
+          appId: 1,
+          installationId: 20,
+          nodeId: 'foo',
+          targetType: 'Organization',
+        },
+        {
+          appId: 3,
+          installationId: 22,
+          nodeId: 'bar',
+          targetType: 'Organization',
+        },
+        {
+          appId: 4,
+          installationId: 23,
+          nodeId: 'random',
+          targetType: 'Organization',
+        },
       ],
       putInstallation,
     });
     expect(result).toEqual([
-      { appId: 3, installationId: 22, nodeId: 'bar' },
-      { appId: 4, installationId: 23, nodeId: 'random' },
+      {
+        appId: 3,
+        installationId: 22,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
+      {
+        appId: 4,
+        installationId: 23,
+        nodeId: 'random',
+        targetType: 'Organization',
+      },
     ]);
     expect(putInstallation).toHaveBeenCalledTimes(2);
   });
@@ -237,7 +317,12 @@ describe('getMissingInstallationsImpl', () => {
     const result = await getMissingInstallationsImpl({
       registeredInstallationsForAppId: [],
       gitHubInstallationsForAppId: [
-        { appId: 1, installationId: 20, nodeId: 'foo' },
+        {
+          appId: 1,
+          installationId: 20,
+          nodeId: 'foo',
+          targetType: 'Organization',
+        },
       ],
       deleteInstallation,
     });
@@ -247,30 +332,77 @@ describe('getMissingInstallationsImpl', () => {
   it('Should return registered installations list if github installations is empty', async () => {
     const result = await getMissingInstallationsImpl({
       registeredInstallationsForAppId: [
-        { appId: 1, installationId: 20, nodeId: 'foo' },
+        {
+          appId: 1,
+          installationId: 20,
+          nodeId: 'foo',
+          targetType: 'Organization',
+        },
       ],
       gitHubInstallationsForAppId: [],
       deleteInstallation,
     });
-    expect(result).toEqual([{ appId: 1, installationId: 20, nodeId: 'foo' }]);
+    expect(result).toEqual([
+      {
+        appId: 1,
+        installationId: 20,
+        nodeId: 'foo',
+        targetType: 'Organization',
+      },
+    ]);
     expect(deleteInstallation).toHaveBeenCalledTimes(1);
   });
   it('Should return registered installations which are not present in github installations', async () => {
     const result = await getMissingInstallationsImpl({
       registeredInstallationsForAppId: [
-        { appId: 1, installationId: 20, nodeId: 'foo' },
-        { appId: 3, installationId: 22, nodeId: 'bar' },
-        { appId: 4, installationId: 23, nodeId: 'random' },
+        {
+          appId: 1,
+          installationId: 20,
+          nodeId: 'foo',
+          targetType: 'Organization',
+        },
+        {
+          appId: 3,
+          installationId: 22,
+          nodeId: 'bar',
+          targetType: 'Organization',
+        },
+        {
+          appId: 4,
+          installationId: 23,
+          nodeId: 'random',
+          targetType: 'Organization',
+        },
       ],
       gitHubInstallationsForAppId: [
-        { appId: 1, installationId: 20, nodeId: 'foo' },
-        { appId: 2, installationId: 21, nodeId: 'baz' },
+        {
+          appId: 1,
+          installationId: 20,
+          nodeId: 'foo',
+          targetType: 'Organization',
+        },
+        {
+          appId: 2,
+          installationId: 21,
+          nodeId: 'baz',
+          targetType: 'Organization',
+        },
       ],
       deleteInstallation,
     });
     expect(result).toEqual([
-      { appId: 3, installationId: 22, nodeId: 'bar' },
-      { appId: 4, installationId: 23, nodeId: 'random' },
+      {
+        appId: 3,
+        installationId: 22,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
+      {
+        appId: 4,
+        installationId: 23,
+        nodeId: 'random',
+        targetType: 'Organization',
+      },
     ]);
     expect(deleteInstallation).toHaveBeenCalledTimes(2);
   });
@@ -279,50 +411,129 @@ describe('getMissingInstallationsImpl', () => {
 describe('leftJoinInstallationsForOneApp', () => {
   it('returns nothing for equivalent arrays', () => {
     const left: InstallationRecord[] = [
-      { appId: 1, installationId: 2, nodeId: 'foo' },
-      { appId: 3, installationId: 4, nodeId: 'bar' },
+      {
+        appId: 1,
+        installationId: 2,
+        nodeId: 'foo',
+        targetType: 'Organization',
+      },
+      {
+        appId: 3,
+        installationId: 4,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
     ];
     const right: InstallationRecord[] = [
-      { appId: 1, installationId: 2, nodeId: 'foo' },
-      { appId: 3, installationId: 4, nodeId: 'bar' },
+      {
+        appId: 1,
+        installationId: 2,
+        nodeId: 'foo',
+        targetType: 'Organization',
+      },
+      {
+        appId: 3,
+        installationId: 4,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
     ];
     const result = leftJoinInstallationsForOneApp(left, right);
     expect(result.length).toBe(0);
   });
   it('returns nothing if only right contains new entries', () => {
     const left: InstallationRecord[] = [
-      { appId: 1, installationId: 2, nodeId: 'foo' },
+      {
+        appId: 1,
+        installationId: 2,
+        nodeId: 'foo',
+        targetType: 'Organization',
+      },
     ];
     const right: InstallationRecord[] = [
-      { appId: 1, installationId: 2, nodeId: 'foo' },
-      { appId: 3, installationId: 4, nodeId: 'bar' },
+      {
+        appId: 1,
+        installationId: 2,
+        nodeId: 'foo',
+        targetType: 'Organization',
+      },
+      {
+        appId: 3,
+        installationId: 4,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
     ];
     const result = leftJoinInstallationsForOneApp(left, right);
     expect(result.length).toBe(0);
   });
   it('returns entries unique to left if so', () => {
     const left: InstallationRecord[] = [
-      { appId: 1, installationId: 2, nodeId: 'foo' },
-      { appId: 3, installationId: 4, nodeId: 'bar' },
+      {
+        appId: 1,
+        installationId: 2,
+        nodeId: 'foo',
+        targetType: 'Organization',
+      },
+      {
+        appId: 3,
+        installationId: 4,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
     ];
     const right: InstallationRecord[] = [
-      { appId: 3, installationId: 4, nodeId: 'bar' },
+      {
+        appId: 3,
+        installationId: 4,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
     ];
     const result = leftJoinInstallationsForOneApp(left, right);
     expect(result.length).toBe(1);
-    expect(result).toEqual([{ appId: 1, installationId: 2, nodeId: 'foo' }]);
+    expect(result).toEqual([
+      {
+        appId: 1,
+        installationId: 2,
+        nodeId: 'foo',
+        targetType: 'Organization',
+      },
+    ]);
   });
   it('returns entries with unique installation ID', () => {
     const left: InstallationRecord[] = [
-      { appId: 1, installationId: 2, nodeId: 'bar' },
-      { appId: 1, installationId: 4, nodeId: 'bar' },
+      {
+        appId: 1,
+        installationId: 2,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
+      {
+        appId: 1,
+        installationId: 4,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
     ];
     const right: InstallationRecord[] = [
-      { appId: 1, installationId: 4, nodeId: 'bar' },
+      {
+        appId: 1,
+        installationId: 4,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
     ];
     const result = leftJoinInstallationsForOneApp(left, right);
     expect(result.length).toBe(1);
-    expect(result).toEqual([{ appId: 1, installationId: 2, nodeId: 'bar' }]);
+    expect(result).toEqual([
+      {
+        appId: 1,
+        installationId: 2,
+        nodeId: 'bar',
+        targetType: 'Organization',
+      },
+    ]);
   });
 });
 

--- a/src/packages/app-framework/test/refresh/refreshCachedData.test.ts
+++ b/src/packages/app-framework/test/refresh/refreshCachedData.test.ts
@@ -27,6 +27,7 @@ const existingInstallationInDDB: InstallationRecord = {
   appId,
   installationId: 888,
   nodeId: 'node-existing',
+  targetType: 'Organization',
 };
 describe('refreshCachedDataImpl', () => {
   beforeEach(() => {
@@ -65,8 +66,18 @@ describe('refreshCachedDataImpl', () => {
       { id: 1000, account: { node_id: 'node-def' } },
     ];
     const expectedUnverified: InstallationRecord[] = [
-      { appId, installationId: 999, nodeId: 'node-abc' },
-      { appId, installationId: 1000, nodeId: 'node-def' },
+      {
+        appId,
+        installationId: 999,
+        nodeId: 'node-abc',
+        targetType: 'Organization',
+      },
+      {
+        appId,
+        installationId: 1000,
+        nodeId: 'node-def',
+        targetType: 'Organization',
+      },
     ];
     (GitHubAPIService as jest.Mock).mockImplementation(() => ({
       getInstallations: jest


### PR DESCRIPTION
### Notes
I have added a `TargetType` field to the installations table to keep track of the type of installations.

### Testing
The installations dynamodb tables does update as expected in my personal aws account when running the refresh API