### PR TITLE
feat: Adding get installations API

### DIFF
--- a/src/packages/app-framework/README.md
+++ b/src/packages/app-framework/README.md
@@ -274,6 +274,22 @@ const response = await client.send(command);
 const installations = response.installations;
 ```
 
+#### Example: Get Installations
+
+```text
+import { GetInstallationsCommand } from '@aws/app-framework-for-github-apps-on-aws-client';
+
+const command = new GetInstallationsCommand({
+  nextToken: '<your nexttoken>'
+  maxResults: '<your maxResults>'
+});
+
+const response = await client.send(command);
+const installations = response.installations;
+```
+
+- `nextToken` and `maxResults` are optional parameters
+
 ## What Resources Are Created by Credential Manager
 
 ### DynamoDB Tables
@@ -361,6 +377,17 @@ retrieves cached installation data from DynamoDB for a given nodeId.
 It provides access to installation records without requiring GitHub API calls.
 It is exposed through a Function URL with IAM authentication,
 and access is controlled via `grantGetInstallationRecord`.
+
+- Permissions:
+  - DynamoDB Read access to Installation table
+
+#### Get Installations
+
+The Get Installations Lambda function
+retrieves cached installation data from DynamoDB installations table.
+It provides access to installation records without requiring GitHub API calls.
+It is exposed through a Function URL with IAM authentication,
+and access is controlled via `grantGetInstallations`.
 
 - Permissions:
   - DynamoDB Read access to Installation table
@@ -456,6 +483,7 @@ This approach provides better flexibility and control over resource management.
 |                    |                                     | `InstallationAccessTokenEndpoint` |
 |                    |                                     | `RefreshCachedDataEndpoint`       |
 |                    |                                     | `InstallationCachedDataEndpoint`  |
+|                    |                                     | `InstallationsEndpoint`           |
 
 ### Tag-Based Access Control
 

--- a/src/packages/app-framework/package.json
+++ b/src/packages/app-framework/package.json
@@ -63,7 +63,7 @@
     "@aws-sdk/util-dynamodb": "^3.777.0",
     "@aws-smithy/server-apigateway": "^1.0.0-alpha.10",
     "@aws-smithy/server-common": "^1.0.0-alpha.10",
-    "@aws/app-framework-for-github-apps-on-aws-ssdk": "^0.0.10",
+    "@aws/app-framework-for-github-apps-on-aws-ssdk": "^0.0.1",
     "@octokit/rest": "^21.1.1",
     "@octokit/types": "^14.0.0",
     "aws-lambda": "^1.0.7",

--- a/src/packages/app-framework/src/credential-manager/constants.ts
+++ b/src/packages/app-framework/src/credential-manager/constants.ts
@@ -14,6 +14,7 @@ export const TAG_VALUES = {
   INSTALLATION_ACCESS_TOKEN_ENDPOINT: 'InstallationAccessTokenEndpoint',
   INSTALLATION_CACHED_DATA_ENDPOINT: 'InstallationCachedDataEndpoint',
   REFRESH_CACHED_DATA_ENDPOINT: 'RefreshCachedDataEndpoint',
+  INSTALLATIONS_ENDPOINT: 'InstallationsEndpoint',
 };
 
 export enum EnvironmentVariables {

--- a/src/packages/app-framework/src/credential-manager/get-installations/getInstallations.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installations/getInstallations.ts
@@ -1,0 +1,52 @@
+import { GetInstallationsOutput } from '@aws/app-framework-for-github-apps-on-aws-ssdk';
+import {
+  getPaginatedInstallationsImpl,
+  GetPaginatedInstallations,
+} from '../../data';
+import { NotFound, ServerError } from '../../error';
+
+export type GetInstallations = ({
+  installationTable,
+  ExclusiveStartKey,
+  Limit,
+  getInstallations,
+}: {
+  installationTable: string;
+  ExclusiveStartKey?: string | undefined;
+  Limit?: number | undefined;
+  getInstallations?: GetPaginatedInstallations;
+}) => Promise<GetInstallationsOutput>;
+
+/**
+ * Retrieves installation data from DynamoDB.
+ * @param installationTable DynamoDB Table that contains installation data mapping to App ID and Node ID
+ * @param getInstallations Function that retrieves installation data from DynamoDB
+ * @returns Installation data containing all installations
+ * @throws NotFound if no installation data is found for the nodeId
+ * @throws ServerError for any other errors during retrieval
+ */
+
+export const getInstallationRecordsImpl: GetInstallations = async ({
+  installationTable,
+  ExclusiveStartKey,
+  Limit,
+  getInstallations = getPaginatedInstallationsImpl,
+}): Promise<GetInstallationsOutput> => {
+  try {
+    const installationData = await getInstallations({
+      tableName: installationTable,
+      ExclusiveStartKey,
+      Limit,
+    });
+    return {
+      installations: installationData.installations,
+      nextToken: installationData.LastEvaluatedKey,
+    };
+  } catch (error) {
+    if (error instanceof NotFound) {
+      throw error;
+    }
+    // For any other error, throw as ServerError
+    throw new ServerError('Server error while retrieving installations');
+  }
+};

--- a/src/packages/app-framework/src/credential-manager/get-installations/getInstallationsOperation.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installations/getInstallationsOperation.ts
@@ -1,0 +1,37 @@
+import {
+  ClientSideError,
+  ServerSideError,
+  GetInstallationsInput,
+  GetInstallationsOutput,
+} from '@aws/app-framework-for-github-apps-on-aws-ssdk';
+import { Operation } from '@aws-smithy/server-common';
+import { getInstallationRecordsImpl } from './getInstallations';
+import { NotFound } from '../../error';
+
+/**
+ * Smithy operation that retrieves installation data and Last Evaluated Key from DynamoDB.
+ * @param input Contains the limit and the Exclusive start key as input
+ * @param _context Contains installationTable name
+ * @returns Installation data for the specified nodeId
+ * @throws ClientSideError if the request is invalid (e.g., nodeId not found)
+ * @throws ServerSideError if there's an internal server error
+ */
+export const getInstallationsOperationImpl: Operation<
+  GetInstallationsInput,
+  GetInstallationsOutput,
+  { installationTable: string }
+> = async (input, _context) => {
+  try {
+    return await getInstallationRecordsImpl({
+      installationTable: _context.installationTable,
+      ExclusiveStartKey: input.nextToken,
+      Limit: input.maxResults,
+    });
+  } catch (error) {
+    if (error instanceof NotFound) {
+      throw new ClientSideError({ message: `Invalid Request: ${error}` });
+    }
+    console.error(error);
+    throw new ServerSideError({ message: 'Internal Server Error' });
+  }
+};

--- a/src/packages/app-framework/src/credential-manager/get-installations/getInstallationsOperation.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installations/getInstallationsOperation.ts
@@ -1,19 +1,16 @@
 import {
-  ClientSideError,
   ServerSideError,
   GetInstallationsInput,
   GetInstallationsOutput,
 } from '@aws/app-framework-for-github-apps-on-aws-ssdk';
 import { Operation } from '@aws-smithy/server-common';
 import { getInstallationRecordsImpl } from './getInstallations';
-import { NotFound } from '../../error';
 
 /**
  * Smithy operation that retrieves installation data and Last Evaluated Key from DynamoDB.
  * @param input Contains the limit and the Exclusive start key as input
  * @param _context Contains installationTable name
  * @returns Installation data for the specified nodeId
- * @throws ClientSideError if the request is invalid (e.g., nodeId not found)
  * @throws ServerSideError if there's an internal server error
  */
 export const getInstallationsOperationImpl: Operation<
@@ -28,9 +25,6 @@ export const getInstallationsOperationImpl: Operation<
       Limit: input.maxResults,
     });
   } catch (error) {
-    if (error instanceof NotFound) {
-      throw new ClientSideError({ message: `Invalid Request: ${error}` });
-    }
     console.error(error);
     throw new ServerSideError({ message: 'Internal Server Error' });
   }

--- a/src/packages/app-framework/src/credential-manager/get-installations/index.handler.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installations/index.handler.ts
@@ -1,0 +1,102 @@
+import {
+  GetInstallationsInput,
+  GetInstallationsOutput,
+  getGetInstallationsHandler,
+} from '@aws/app-framework-for-github-apps-on-aws-ssdk';
+import {
+  convertEvent,
+  convertVersion1Response,
+} from '@aws-smithy/server-apigateway';
+import {
+  APIGatewayEventRequestContextIAMAuthorizer,
+  APIGatewayEventRequestContextV2WithAuthorizer,
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResultV2,
+} from 'aws-lambda';
+import { EnvironmentVariables } from '../constants';
+import { getInstallationsOperationImpl } from './getInstallationsOperation';
+import { EnvironmentError } from '../../error';
+
+/**
+ * Lambda entry point for handling installation data requests.
+ */
+export const handler = async (
+  event: APIGatewayProxyEventV2,
+): Promise<APIGatewayProxyResultV2> => {
+  const context =
+    event.requestContext as APIGatewayEventRequestContextV2WithAuthorizer<APIGatewayEventRequestContextIAMAuthorizer>;
+  const result: APIGatewayProxyResultV2 = await handlerImpl({ event });
+  // Serialize/deserialize needed because APIGatewayProxyResultV2 is a union type,
+  // string | APIGatewayProxyStructuredResultV2 | T,
+  // TypeScript can't guarantee 'body' property exists.
+  const parseResponse = JSON.parse(JSON.stringify(result));
+  const body = parseResponse.body as GetInstallationsOutput;
+  if (!!body) {
+    const logResponse = {
+      caller: context.authorizer.iam.userArn,
+      installations: body,
+    };
+    console.log(JSON.stringify(logResponse));
+  }
+  return result;
+};
+
+export type Handler = ({
+  event,
+  checkEnvironment,
+  getInstallationRecordOperation,
+}: {
+  event: APIGatewayProxyEventV2;
+  checkEnvironment?: CheckEnvironment;
+  getInstallationRecordOperation?: (
+    input: GetInstallationsInput,
+    _context: { installationTable: string },
+  ) => Promise<GetInstallationsOutput>;
+}) => Promise<APIGatewayProxyResultV2>;
+
+/**
+ * Core Lambda handler logic for processing GetInstallations requests.
+ * @param event Lambda event from Lambda Function URL containing nodeId
+ * @param checkEnvironment Function to check environment configuration for installationTable
+ * @param getInstallationRecordOperation Operation for retrieving installation records
+ * @returns API Gateway response containing installation data
+ */
+
+export const handlerImpl: Handler = async ({
+  event,
+  checkEnvironment = checkEnvironmentImpl,
+  getInstallationRecordOperation = getInstallationsOperationImpl,
+}) => {
+  console.log('Event received', event);
+  const getTableName = checkEnvironment();
+  const httpRequest = convertEvent(event);
+  console.log('Converted Http Request:', JSON.stringify(httpRequest));
+  const installationRecordHandler = getGetInstallationsHandler(
+    getInstallationRecordOperation,
+  );
+  const result = await installationRecordHandler.handle(
+    httpRequest,
+    getTableName,
+  );
+  return convertVersion1Response(result);
+};
+
+export type CheckEnvironment = () => {
+  installationTable: string;
+};
+
+/**
+ * Retrieves Installation Table name from environment variables.
+ * @returns Object containing the installation table name
+ * @throws EnvironmentError if Installation Table name is not present
+ */
+export const checkEnvironmentImpl: CheckEnvironment = () => {
+  const installationTableName =
+    process.env[EnvironmentVariables.INSTALLATION_TABLE_NAME]!;
+  if (!installationTableName) {
+    throw new EnvironmentError(
+      `No value found in ${EnvironmentVariables.INSTALLATION_TABLE_NAME} environment variable.`,
+    );
+  }
+  return { installationTable: installationTableName };
+};

--- a/src/packages/app-framework/src/credential-manager/get-installations/index.ts
+++ b/src/packages/app-framework/src/credential-manager/get-installations/index.ts
@@ -1,0 +1,65 @@
+import { Tags } from 'aws-cdk-lib';
+import { ITable } from 'aws-cdk-lib/aws-dynamodb';
+import {
+  FunctionUrlAuthType,
+  HttpMethod,
+  IFunctionUrl,
+} from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+import { LAMBDA_DEFAULTS } from '../../lambdaDefaults';
+import { EnvironmentVariables, TAG_KEYS, TAG_VALUES } from '../constants';
+
+export interface InstallationCachedDataProps {
+  // DynamoDB table containing installation data
+  readonly InstallationTable: ITable;
+}
+
+/**
+ * CDK construct that creates a Lambda function and Function URL for retrieving all installations.
+ * This construct provides an endpoint to get GitHub App installation records from DynamoDB.
+ */
+export class GetInstallations extends Construct {
+  // The Lambda function that handles installation data requests
+  readonly lambdaHandler: NodejsFunction;
+  // The Function URL for invoking the Lambda function
+  readonly functionUrl: IFunctionUrl;
+  constructor(
+    scope: Construct,
+    id: string,
+    props: InstallationCachedDataProps,
+  ) {
+    super(scope, id);
+    // Create Lambda function for handling installation data requests
+    this.lambdaHandler = new NodejsFunction(this, 'handler', {
+      ...LAMBDA_DEFAULTS,
+      bundling: {
+        ...LAMBDA_DEFAULTS.bundling,
+        nodeModules: ['re2-wasm'],
+      },
+      environment: {
+        [EnvironmentVariables.INSTALLATION_TABLE_NAME]:
+          props.InstallationTable.tableName,
+      },
+      description: 'Get all Installations',
+      memorySize: 512,
+    });
+
+    // Create Function URL for the Lambda function with IAM authentication
+    this.functionUrl = this.lambdaHandler.addFunctionUrl({
+      authType: FunctionUrlAuthType.AWS_IAM,
+      cors: {
+        allowedOrigins: ['*'],
+        allowedMethods: [HttpMethod.POST],
+        allowedHeaders: ['*'],
+      },
+    });
+    // Add tags to the Function URL for resource management
+    Tags.of(this.functionUrl).add(
+      TAG_KEYS.CREDENTIAL_MANAGER,
+      TAG_VALUES.INSTALLATIONS_ENDPOINT,
+    );
+    // Grant the Lambda function read access to the installation table
+    props.InstallationTable.grantReadData(this.lambdaHandler);
+  }
+}

--- a/src/packages/app-framework/src/credential-manager/index.ts
+++ b/src/packages/app-framework/src/credential-manager/index.ts
@@ -236,6 +236,21 @@ export class CredentialManager extends NestedStack {
     );
   }
 
+  grantGetInstallations(grantee: IGrantable) {
+    grantee.grantPrincipal.addToPrincipalPolicy(
+      new PolicyStatement({
+        actions: ['lambda:InvokeFunctionUrl'],
+        effect: Effect.ALLOW,
+        resources: [this.installationsLambdaArn],
+        conditions: {
+          StringEquals: {
+            'lambda:FunctionUrlAuthType': 'AWS_IAM',
+          },
+        },
+      }),
+    );
+  }
+
   /**
    * Dashboard to help track rate limits pf GitHub App API calls
    * @param limit is the rate limit percent the dashboard will alarm on

--- a/src/packages/app-framework/src/credential-manager/index.ts
+++ b/src/packages/app-framework/src/credential-manager/index.ts
@@ -18,6 +18,7 @@ import { SERVICE_NAME } from './constants';
 import { GitHubAppToken } from './get-app-token/appToken';
 import { InstallationAcessTokenGenerator } from './get-installation-access-token';
 import { InstallationCachedData } from './get-installation-data';
+import { GetInstallations } from './get-installations';
 import { InstallationTracker } from './installation-tracker';
 import { RateLimitTracker } from './rate-limit-tracker';
 import {
@@ -47,6 +48,8 @@ export class CredentialManager extends NestedStack {
   readonly refreshCachedDataLambdaArn: string;
   readonly installationRecordLambdaArn: string;
   readonly installationRecordEndpoint: string;
+  readonly installationsLambdaArn: string;
+  readonly installationsEndpoint: string;
 
   constructor(scope: Construct, id: string, props?: CredentialManagerProps) {
     super(scope, id, props);
@@ -164,6 +167,12 @@ export class CredentialManager extends NestedStack {
     this.installationRecordLambdaArn =
       installationData.lambdaHandler.functionArn;
     this.installationRecordEndpoint = installationData.functionUrl.url;
+    // Creates a construct to retrieve all cached installations
+    const getInstallations = new GetInstallations(this, 'GetInstallations', {
+      InstallationTable: this.installationTable,
+    });
+    this.installationsLambdaArn = getInstallations.lambdaHandler.functionArn;
+    this.installationsEndpoint = getInstallations.functionUrl.url;
   }
 
   // Grants a caller permission to invoke the app token lambda Function URL.

--- a/src/packages/app-framework/src/data.ts
+++ b/src/packages/app-framework/src/data.ts
@@ -299,3 +299,44 @@ export const getInstallationsDataByNodeId: GetInstallationsByNodeId = async ({
   }
   return result;
 };
+
+export type GetPaginatedInstallations = ({
+  tableName,
+  ExclusiveStartKey,
+  Limit,
+}: {
+  tableName: string;
+  ExclusiveStartKey?: string | undefined;
+  Limit?: number | undefined;
+}) => Promise<{
+  installations: InstallationRecord[];
+  LastEvaluatedKey: string | undefined;
+}>;
+
+export const getPaginatedInstallationsImpl: GetPaginatedInstallations = async ({
+  tableName,
+  ExclusiveStartKey,
+  Limit,
+}) => {
+  const getInstallations = new TableOperations({ TableName: tableName });
+  const installations: InstallationRecord[] = [];
+  const scan = await getInstallations.paginated_scan({
+    ExclusiveStartKey,
+    Limit,
+  });
+  const itemList = scan.items;
+  const LastEvaluatedKey = scan.LastEvaluatedKey;
+  itemList.map((item) => {
+    const appId: number = item.AppId;
+    const installationId: number = item.InstallationId;
+    const targetType: string = item.TargetType;
+    const nodeId: string = item.NodeId ?? '';
+    installations.push({
+      appId,
+      nodeId,
+      installationId,
+      targetType,
+    });
+  });
+  return { installations, LastEvaluatedKey };
+};

--- a/src/packages/app-framework/test/data.test.ts
+++ b/src/packages/app-framework/test/data.test.ts
@@ -7,6 +7,7 @@ import {
   deleteInstallationImpl,
   getInstallationsImpl,
   getInstallationsDataByNodeId,
+  getPaginatedInstallationsImpl,
 } from '../src/data';
 import { DataError, NotFound } from '../src/error';
 import { TableOperations } from '../src/tableOperations';
@@ -24,6 +25,8 @@ const mockAppId = 12345;
 const mockTableName = 'validAppTableName';
 const mockNodeId = 'foo';
 const mockInstallationId = 123456;
+const mockAppId2 = 12346;
+const mockInstallationId2 = 123457;
 const mockTargetType = 'Organization';
 const mockArn = 'arn:aws:kms:region:account:key/mock-key-id';
 describe('getKeyArnByID', () => {
@@ -327,8 +330,6 @@ describe('getInstallationId', () => {
 
   describe('GetInstallationsByNodeId', () => {
     it('should successfully retrieve all installations for a specific nodeId from DynamoDB', async () => {
-      const mockAppId2 = 12346;
-      const mockInstallationId2 = 123457;
       mockTableOperations.prototype.query.mockResolvedValue([
         {
           AppId: mockAppId,
@@ -415,6 +416,59 @@ describe('getInstallationId', () => {
         },
         indexName: 'NodeID',
       });
+    });
+  });
+
+  describe('GetPaginatedInstallations', () => {
+    it('should successfully retrieve all installations from DynamoDB', async () => {
+      mockTableOperations.prototype.paginated_scan.mockResolvedValue({
+        LastEvaluatedKey: 'encodedkey',
+        items: [
+          {
+            AppId: mockAppId,
+            InstallationId: mockInstallationId,
+            TargetType: mockTargetType,
+          },
+          {
+            AppId: mockAppId2,
+            InstallationId: mockInstallationId2,
+            NodeId: mockNodeId,
+            TargetType: mockTargetType,
+          },
+        ],
+      });
+      const result = await getPaginatedInstallationsImpl({
+        tableName: mockTableName,
+      });
+      expect(result.LastEvaluatedKey).toEqual('encodedkey');
+      expect(result.installations).toEqual([
+        {
+          appId: mockAppId,
+          nodeId: '',
+          installationId: mockInstallationId,
+          targetType: mockTargetType,
+        },
+        {
+          appId: mockAppId2,
+          nodeId: mockNodeId,
+          installationId: mockInstallationId2,
+          targetType: mockTargetType,
+        },
+      ]);
+      expect(TableOperations).toHaveBeenCalledWith({
+        TableName: mockTableName,
+      });
+      expect(mockTableOperations.prototype.paginated_scan).toHaveBeenCalled();
+    });
+    it('should throw an exception if DynamoDB call fails', async () => {
+      mockTableOperations.prototype.paginated_scan.mockRejectedValue(() => {
+        throw new Error('DynamoDB service error');
+      });
+      await expect(
+        getPaginatedInstallationsImpl({
+          tableName: mockTableName,
+        }),
+      ).rejects.toThrow('DynamoDB service error');
     });
   });
 });

--- a/src/packages/app-framework/test/get-installations/getInstallations.test.ts
+++ b/src/packages/app-framework/test/get-installations/getInstallations.test.ts
@@ -1,0 +1,83 @@
+import { getInstallationRecordsImpl } from '../../src/credential-manager/get-installations/getInstallations';
+import { InstallationRecord } from '../../src/data';
+import { NotFound } from '../../src/error';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getInstallationRecordsImpl', () => {
+  const mockNodeId = 'test-node-id';
+  const mockInstallationTable = 'test-installation-table';
+  const mockInstallationData: InstallationRecord[] = [
+    {
+      appId: 12345,
+      installationId: 67890,
+      nodeId: mockNodeId,
+      targetType: 'Organization',
+    },
+    {
+      appId: 54321,
+      installationId: 98765,
+      nodeId: mockNodeId,
+      targetType: 'Organization',
+    },
+  ];
+
+  it('should successfully return installation data', async () => {
+    const mockGetInstallations = jest
+      .fn()
+      .mockResolvedValue({ installations: mockInstallationData });
+
+    const result = await getInstallationRecordsImpl({
+      installationTable: mockInstallationTable,
+      getInstallations: mockGetInstallations,
+    });
+
+    expect(result).toEqual({
+      installations: mockInstallationData,
+    });
+  });
+
+  it('should successfully return installation data and return last evaluated key when found', async () => {
+    const mockGetInstallations = jest.fn().mockResolvedValue({
+      installations: mockInstallationData,
+      LastEvaluatedKey: 'encodedKey',
+    });
+
+    const result = await getInstallationRecordsImpl({
+      installationTable: mockInstallationTable,
+      Limit: 10,
+      getInstallations: mockGetInstallations,
+    });
+
+    expect(result).toEqual({
+      installations: mockInstallationData,
+      nextToken: 'encodedKey',
+    });
+  });
+
+  it('should throw NotFound error when getInstallationRecords throws NotFound', async () => {
+    const notFoundError = new NotFound('No installations found');
+    const mockGetInstallations = jest.fn().mockRejectedValue(notFoundError);
+
+    await expect(
+      getInstallationRecordsImpl({
+        installationTable: mockInstallationTable,
+        getInstallations: mockGetInstallations,
+      }),
+    ).rejects.toThrow(NotFound);
+  });
+
+  it('should throw ServerError when getInstallationRecords throws a DynamoDB error', async () => {
+    const dynamoError = new Error('DynamoDB service error');
+    const mockGetInstallations = jest.fn().mockRejectedValue(dynamoError);
+
+    await expect(
+      getInstallationRecordsImpl({
+        installationTable: mockInstallationTable,
+        getInstallations: mockGetInstallations,
+      }),
+    ).rejects.toThrow('Server error while retrieving installations');
+  });
+});

--- a/src/packages/app-framework/test/get-installations/getInstallations.test.ts
+++ b/src/packages/app-framework/test/get-installations/getInstallations.test.ts
@@ -1,6 +1,5 @@
 import { getInstallationRecordsImpl } from '../../src/credential-manager/get-installations/getInstallations';
 import { InstallationRecord } from '../../src/data';
-import { NotFound } from '../../src/error';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -55,18 +54,6 @@ describe('getInstallationRecordsImpl', () => {
       installations: mockInstallationData,
       nextToken: 'encodedKey',
     });
-  });
-
-  it('should throw NotFound error when getInstallationRecords throws NotFound', async () => {
-    const notFoundError = new NotFound('No installations found');
-    const mockGetInstallations = jest.fn().mockRejectedValue(notFoundError);
-
-    await expect(
-      getInstallationRecordsImpl({
-        installationTable: mockInstallationTable,
-        getInstallations: mockGetInstallations,
-      }),
-    ).rejects.toThrow(NotFound);
   });
 
   it('should throw ServerError when getInstallationRecords throws a DynamoDB error', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -825,12 +825,20 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/types@3.862.0", "@aws-sdk/types@^3.222.0", "@aws-sdk/types@^3.267.0", "@aws-sdk/types@^3.4.1":
+"@aws-sdk/types@3.862.0", "@aws-sdk/types@^3.222.0", "@aws-sdk/types@^3.267.0":
   version "3.862.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.862.0.tgz#2f5622e1aa3a5281d4f419f5d2c90f87dd5ff0cf"
   integrity sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==
   dependencies:
     "@smithy/types" "^4.3.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.4.1":
+  version "3.887.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.887.0.tgz#989f3b67d7ddb97443e4bdb80ad2313c604b240d"
+  integrity sha512-fmTEJpUhsPsovQ12vZSpVTEP/IaRoJAMBGQXlQNjtCpkBp6Iq3KQDa/HDaPINE+3xxo6XvTdtibsNOd5zJLV9A==
+  dependencies:
+    "@smithy/types" "^4.5.0"
     tslib "^2.6.2"
 
 "@aws-sdk/util-dynamodb@^3.777.0":
@@ -937,37 +945,6 @@
     "@aws-sdk/types" "^3.267.0"
     re2-wasm "^1.0.2"
     tslib "^1.8.0"
-
-"@aws/app-framework-for-github-apps-on-aws-ssdk@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@aws/app-framework-for-github-apps-on-aws-ssdk/-/app-framework-for-github-apps-on-aws-ssdk-0.0.10.tgz#1655347691668b2a67e941995c9ed4184fc73ba0"
-  integrity sha512-0NhoxWxEcSv1CRjHod2lvQjZoKwGXBHPxI57S4eIqWLkKeyApoGpWR8mvsYn6Dw1ebLD+MrgUfKMcZk9hf+RyA==
-  dependencies:
-    "@aws-crypto/sha256-browser" "5.2.0"
-    "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "3.775.0"
-    "@aws-sdk/types" "3.775.0"
-    "@aws-smithy/server-common" "1.0.0-alpha.10"
-    "@smithy/config-resolver" "^4.1.0"
-    "@smithy/fetch-http-handler" "^5.0.2"
-    "@smithy/hash-node" "^4.0.2"
-    "@smithy/invalid-dependency" "^4.0.2"
-    "@smithy/middleware-content-length" "^4.0.2"
-    "@smithy/middleware-retry" "^4.1.0"
-    "@smithy/middleware-serde" "^4.0.3"
-    "@smithy/middleware-stack" "^4.0.2"
-    "@smithy/node-http-handler" "^4.0.4"
-    "@smithy/protocol-http" "^5.1.0"
-    "@smithy/smithy-client" "^4.2.0"
-    "@smithy/types" "^4.2.0"
-    "@smithy/url-parser" "^4.0.2"
-    "@smithy/util-base64" "^4.0.0"
-    "@smithy/util-body-length-browser" "^4.0.0"
-    "@smithy/util-body-length-node" "^4.0.0"
-    "@smithy/util-defaults-mode-browser" "^4.0.8"
-    "@smithy/util-defaults-mode-node" "^4.0.8"
-    "@smithy/util-utf8" "^4.0.0"
-    tslib "^2.6.2"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
   version "7.27.1"
@@ -2725,7 +2702,7 @@
 
 "@smithy/service-error-classification@^2.0.4":
   version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz#0568a977cc0db36299d8703a5d8609c1f600c005"
+  resolved "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz#0568a977cc0db36299d8703a5d8609c1f600c005"
   integrity sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==
   dependencies:
     "@smithy/types" "^2.12.0"
@@ -2781,7 +2758,7 @@
 
 "@smithy/types@^2.12.0":
   version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-2.12.0.tgz#c44845f8ba07e5e8c88eda5aed7e6a0c462da041"
+  resolved "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz#c44845f8ba07e5e8c88eda5aed7e6a0c462da041"
   integrity sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==
   dependencies:
     tslib "^2.6.2"
@@ -2790,6 +2767,13 @@
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.3.2.tgz#66ac513e7057637de262e41ac15f70cf464c018a"
   integrity sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/types@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/@smithy/types/-/types-4.5.0.tgz#850e334662a1ef1286c35814940c80880400a370"
+  integrity sha512-RkUpIOsVlAwUIZXO1dsz8Zm+N72LClFfsNqf173catVlvRZiwPy0x2u0JLEA4byreOPKDZPGjmPDylMoP8ZJRg==
   dependencies:
     tslib "^2.6.2"
 
@@ -3070,7 +3054,7 @@
 
 "@types/body-parser@*":
   version "1.19.6"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
+  resolved "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
   integrity sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==
   dependencies:
     "@types/connect" "*"
@@ -3078,14 +3062,14 @@
 
 "@types/cls-hooked@^4.3.3":
   version "4.3.9"
-  resolved "https://registry.yarnpkg.com/@types/cls-hooked/-/cls-hooked-4.3.9.tgz#2cff2f7ca961d53213ef626f96afa986a66d3fad"
+  resolved "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.9.tgz#2cff2f7ca961d53213ef626f96afa986a66d3fad"
   integrity sha512-CMtHMz6Q/dkfcHarq9nioXH8BDPP+v5xvd+N90lBQ2bdmu06UvnLDqxTKoOJzz4SzIwb/x9i4UXGAAcnUDuIvg==
   dependencies:
     "@types/node" "*"
 
 "@types/connect@*":
   version "3.4.38"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
   integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
   dependencies:
     "@types/node" "*"
@@ -3097,7 +3081,7 @@
 
 "@types/express-serve-static-core@^5.0.0":
   version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz#2fa94879c9d46b11a5df4c74ac75befd6b283de6"
+  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz#2fa94879c9d46b11a5df4c74ac75befd6b283de6"
   integrity sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==
   dependencies:
     "@types/node" "*"
@@ -3107,7 +3091,7 @@
 
 "@types/express@*":
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.3.tgz#6c4bc6acddc2e2a587142e1d8be0bce20757e956"
+  resolved "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz#6c4bc6acddc2e2a587142e1d8be0bce20757e956"
   integrity sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==
   dependencies:
     "@types/body-parser" "*"
@@ -3123,7 +3107,7 @@
 
 "@types/http-errors@*":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
+  resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
   integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
@@ -3165,7 +3149,7 @@
 
 "@types/mime@^1":
   version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
+  resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
   integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
 
 "@types/minimatch@^3.0.3":
@@ -3187,7 +3171,7 @@
 
 "@types/mysql@*":
   version "2.15.27"
-  resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.27.tgz#fb13b0e8614d39d42f40f381217ec3215915f1e9"
+  resolved "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz#fb13b0e8614d39d42f40f381217ec3215915f1e9"
   integrity sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==
   dependencies:
     "@types/node" "*"
@@ -3220,7 +3204,7 @@
 
 "@types/pg@*":
   version "8.15.5"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.5.tgz#ef43e0f33b62dac95cae2f042888ec7980b30c09"
+  resolved "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz#ef43e0f33b62dac95cae2f042888ec7980b30c09"
   integrity sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==
   dependencies:
     "@types/node" "*"
@@ -3229,17 +3213,17 @@
 
 "@types/qs@*":
   version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.14.0.tgz#d8b60cecf62f2db0fb68e5e006077b9178b85de5"
+  resolved "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz#d8b60cecf62f2db0fb68e5e006077b9178b85de5"
   integrity sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==
 
 "@types/range-parser@*":
   version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
+  resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
 "@types/send@*":
   version "0.17.5"
-  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.5.tgz#d991d4f2b16f2b1ef497131f00a9114290791e74"
+  resolved "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz#d991d4f2b16f2b1ef497131f00a9114290791e74"
   integrity sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==
   dependencies:
     "@types/mime" "^1"
@@ -3247,7 +3231,7 @@
 
 "@types/serve-static@*":
   version "1.15.8"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.8.tgz#8180c3fbe4a70e8f00b9f70b9ba7f08f35987877"
+  resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz#8180c3fbe4a70e8f00b9f70b9ba7f08f35987877"
   integrity sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==
   dependencies:
     "@types/http-errors" "*"
@@ -3782,7 +3766,7 @@ async-function@^1.0.0:
 
 async-hook-jl@^1.7.6:
   version "1.7.6"
-  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  resolved "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
   integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
   dependencies:
     stack-chain "^1.3.7"
@@ -3799,7 +3783,7 @@ asynckit@^0.4.0:
 
 atomic-batcher@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/atomic-batcher/-/atomic-batcher-1.0.2.tgz#d16901d10ccec59516c197b9ccd8930689b813b4"
+  resolved "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz#d16901d10ccec59516c197b9ccd8930689b813b4"
   integrity sha512-EFGCRj4kLX1dHv1cDzTk+xbjBFj1GnJDpui52YmEcxxHHEWjYyT6l51U7n6WQ28osZH4S9gSybxe56Vm7vB61Q==
 
 available-typed-arrays@^1.0.7:
@@ -3893,7 +3877,7 @@ aws-sdk@^2.814.0:
 
 aws-xray-sdk-core@3.10.3:
   version "3.10.3"
-  resolved "https://registry.yarnpkg.com/aws-xray-sdk-core/-/aws-xray-sdk-core-3.10.3.tgz#14af55243dbfdffdbbb2cca65302dd16a45a276a"
+  resolved "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.10.3.tgz#14af55243dbfdffdbbb2cca65302dd16a45a276a"
   integrity sha512-bltsLAr4juMJJ2tT5/L/CtwUGIvHihtPe6SO/z3jjOD73PHhOYxcuwCMFFyTbTy5S4WThJO32oZk7r+pg3ZoCQ==
   dependencies:
     "@aws-sdk/types" "^3.4.1"
@@ -3905,28 +3889,28 @@ aws-xray-sdk-core@3.10.3:
 
 aws-xray-sdk-express@3.10.3:
   version "3.10.3"
-  resolved "https://registry.yarnpkg.com/aws-xray-sdk-express/-/aws-xray-sdk-express-3.10.3.tgz#26bd6d63d08724f330f8168319cc81a29be5d680"
+  resolved "https://registry.npmjs.org/aws-xray-sdk-express/-/aws-xray-sdk-express-3.10.3.tgz#26bd6d63d08724f330f8168319cc81a29be5d680"
   integrity sha512-ynmpcM3X8QRt00UmgwIW2hYAJkw8vPQtdgX0SJGjizbzbAH4n3H6zfOJfq54RxANYzHSyeS/I6J3PlBJgnYQjA==
   dependencies:
     "@types/express" "*"
 
 aws-xray-sdk-mysql@3.10.3:
   version "3.10.3"
-  resolved "https://registry.yarnpkg.com/aws-xray-sdk-mysql/-/aws-xray-sdk-mysql-3.10.3.tgz#5d85ecffe6ac25e80a941fdebe981d25e4592e79"
+  resolved "https://registry.npmjs.org/aws-xray-sdk-mysql/-/aws-xray-sdk-mysql-3.10.3.tgz#5d85ecffe6ac25e80a941fdebe981d25e4592e79"
   integrity sha512-aP9dXWWn2zhSr4I+IUnkwlGoLc7/pzjFegiW3w7qcFP+WwTU4tbme99igqT0edPVFSOeGMq8zMt/IL2gmER7Lg==
   dependencies:
     "@types/mysql" "*"
 
 aws-xray-sdk-postgres@3.10.3:
   version "3.10.3"
-  resolved "https://registry.yarnpkg.com/aws-xray-sdk-postgres/-/aws-xray-sdk-postgres-3.10.3.tgz#d5b05634497cf530f5b03957f424347d15e1945d"
+  resolved "https://registry.npmjs.org/aws-xray-sdk-postgres/-/aws-xray-sdk-postgres-3.10.3.tgz#d5b05634497cf530f5b03957f424347d15e1945d"
   integrity sha512-Etz1W8UltrG8Up2tAh6OizCOXQFaAcgDAs8EoOaELnorWKhQe+iG6+vgZSAVnNKiyEAFRY97O9PPFD2U05RqNg==
   dependencies:
     "@types/pg" "*"
 
 aws-xray-sdk@^3.10.3:
   version "3.10.3"
-  resolved "https://registry.yarnpkg.com/aws-xray-sdk/-/aws-xray-sdk-3.10.3.tgz#959a3f5ee9f04ce36f41f60dd94ab5fef7e47d80"
+  resolved "https://registry.npmjs.org/aws-xray-sdk/-/aws-xray-sdk-3.10.3.tgz#959a3f5ee9f04ce36f41f60dd94ab5fef7e47d80"
   integrity sha512-qUB7iKWQ5UaTHyZ38jDinIYEE8kJ6LtuTFzHQGeyrlyXKEAxHzU1jOzDClChs/vjG51Zz3P71mEvxHh236Hbyw==
   dependencies:
     aws-xray-sdk-core "3.10.3"
@@ -4357,7 +4341,7 @@ clone@^2.1.2:
 
 cls-hooked@^4.2.2:
   version "4.2.2"
-  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  resolved "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
   integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
   dependencies:
     async-hook-jl "^1.7.6"
@@ -4911,7 +4895,7 @@ electron-to-chromium@^1.5.211:
 
 emitter-listener@^1.0.1:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
+  resolved "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
   integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
   dependencies:
     shimmer "^1.2.0"
@@ -8702,17 +8686,17 @@ path-type@^3.0.0:
 
 pg-int8@1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  resolved "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
 
 pg-protocol@*:
   version "1.10.3"
-  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.10.3.tgz#ac9e4778ad3f84d0c5670583bab976ea0a34f69f"
+  resolved "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz#ac9e4778ad3f84d0c5670583bab976ea0a34f69f"
   integrity sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==
 
 pg-types@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  resolved "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
   integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
   dependencies:
     pg-int8 "1.0.1"
@@ -8790,22 +8774,22 @@ postcss-selector-parser@^6.0.10:
 
 postgres-array@~2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  resolved "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
   integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
 
 postgres-bytea@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  resolved "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
   integrity sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==
 
 postgres-date@~1.0.4:
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  resolved "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
   integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
 
 postgres-interval@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  resolved "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
   integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
   dependencies:
     xtend "^4.0.0"
@@ -9945,7 +9929,7 @@ shelljs@^0.9.2:
 
 shimmer@^1.2.0:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  resolved "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 shx@^0.4.0:
@@ -10188,7 +10172,7 @@ stable-hash@^0.0.5:
 
 stack-chain@^1.3.7:
   version "1.3.7"
-  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  resolved "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
   integrity sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==
 
 stack-utils@^2.0.3:


### PR DESCRIPTION
### Notes
I have added an API to retrieve all installations that are currently stored by the framework. The API takes optional inputs of `nextToken` for starting a query with the next token and `maxResults` for limiting the outputs returned by the API.

### Testing
It passes all unit tests and is able to get respective outputs based on `nextToken` and `maxResults` input values.