### PR TITLE
fix: Set App token exp time to 8 minutes

### DIFF
--- a/src/packages/app-framework-ops-tools/src/importPrivateKey.ts
+++ b/src/packages/app-framework-ops-tools/src/importPrivateKey.ts
@@ -667,7 +667,7 @@ export const validateJWTImpl: ValidateJWT = async ({ appId, signFunction }) => {
     const now = Math.floor(Date.now() / 1000);
     const payload = {
       iat: now - 60,
-      exp: now + 10 * 60,
+      exp: now + 8 * 60,
       iss: appId,
     };
     const encodedHeader = Buffer.from(JSON.stringify(header)).toString(

--- a/src/packages/app-framework/README.md
+++ b/src/packages/app-framework/README.md
@@ -367,6 +367,7 @@ The App Token Generator is a Lambda function
 that generates short-lived JWTs used to authenticate the GitHub App itself.
 It exposes a Function URL with AWS IAM authentication
 and performs RSA signing operations through KMS.
+The generated JWTs have an 8-minute expiration time to ensure compliance with GitHub's validation requirements while accounting for clock drift.
 Access is restricted to IAM principals explicitly granted through `grantGetAppToken`.
 
 - Permissions:
@@ -445,6 +446,16 @@ App ID, and installation ID.
 This enables proper tracking of API usage for each GitHub App.
 
 ## Security Considerations
+
+### JWT Token Expiration
+
+The Credential Manager generates GitHub App JWTs with an 8-minute expiration time (`exp`), 
+which is shorter than GitHub's documented maximum of 10 minutes. 
+This conservative approach ensures compatibility with GitHub's JWT validation, 
+which enforces that the time span between the issued-at time (`iat`) and expiration time (`exp`) 
+must not exceed 10 minutes. Since the `iat` is backdated by 60 seconds to account for clock drift, 
+using an 8-minute expiration ensures the total JWT lifetime stays well within GitHub's limits 
+and provides a safety margin for any timing variations between systems.
 
 ### Data Protection
 

--- a/src/packages/app-framework/README.md
+++ b/src/packages/app-framework/README.md
@@ -367,7 +367,8 @@ The App Token Generator is a Lambda function
 that generates short-lived JWTs used to authenticate the GitHub App itself.
 It exposes a Function URL with AWS IAM authentication
 and performs RSA signing operations through KMS.
-The generated JWTs have an 8-minute expiration time to ensure compliance with GitHub's validation requirements while accounting for clock drift.
+The generated JWTs have an 8-minute expiration time to ensure compliance
+with GitHub's validation requirements while accounting for clock drift.
 Access is restricted to IAM principals explicitly granted through `grantGetAppToken`.
 
 - Permissions:
@@ -449,13 +450,19 @@ This enables proper tracking of API usage for each GitHub App.
 
 ### JWT Token Expiration
 
-The Credential Manager generates GitHub App JWTs with an 8-minute expiration time (`exp`), 
-which is shorter than GitHub's documented maximum of 10 minutes. 
-This conservative approach ensures compatibility with GitHub's JWT validation, 
-which enforces that the time span between the issued-at time (`iat`) and expiration time (`exp`) 
-must not exceed 10 minutes. Since the `iat` is backdated by 60 seconds to account for clock drift, 
-using an 8-minute expiration ensures the total JWT lifetime stays well within GitHub's limits 
-and provides a safety margin for any timing variations between systems.
+The Credential Manager generates GitHub App JWTs
+with an 8-minute expiration time (`exp`),
+which is shorter than GitHub's documented maximum of 10 minutes.
+This conservative approach ensures
+compatibility with GitHub's JWT validation,
+which enforces that the time span between the
+issued-at time (`iat`) and expiration time (`exp`)
+must not exceed 10 minutes. Since the `iat` is
+backdated by 60 seconds to account for clock drift,
+using an 8-minute expiration ensures the total JWT lifetime
+stays well within GitHub's limits
+and provides a safety margin for
+any timing variations between systems.
 
 ### Data Protection
 

--- a/src/packages/app-framework/src/credential-manager/get-app-token/getAppToken.ts
+++ b/src/packages/app-framework/src/credential-manager/get-app-token/getAppToken.ts
@@ -51,7 +51,7 @@ export const getAppTokenImpl: GetAppToken = async ({
       typ: 'JWT',
     };
     const now = Math.floor(Date.now() / 1000);
-    const exp = now + 10 * 60;
+    const exp = now + 8 * 60;
     const payload = {
       iat: now - 60,
       exp,


### PR DESCRIPTION
Fixes #
Set App token exp time to 8 minutes to meet the GitHub requirement that `exp` be no more than 10 minutes after adding buffer time to prevent clock drift.