### PR TITLE
fix: lambda function permissions insufficient

### DIFF
--- a/src/packages/app-framework-test-app/test/TESTING.md
+++ b/src/packages/app-framework-test-app/test/TESTING.md
@@ -44,7 +44,7 @@ Ensure AWS credentials have these additional required permissions:
 ### **Lambda Permission (Required for invoke Lambda function)**
 
 - `lambda:InvokeFunctionUrl` - Invoke Lambda function URL
-- `lambda:InvokeFunction` - Invoke Lambda function (required since Oct 2025 for function URLs with AWS_IAM auth)
+- `lambda:InvokeFunction` - Invoke Lambda function
 
 ## Prerequisites
 

--- a/src/packages/app-framework-test-app/test/TESTING.md
+++ b/src/packages/app-framework-test-app/test/TESTING.md
@@ -44,6 +44,7 @@ Ensure AWS credentials have these additional required permissions:
 ### **Lambda Permission (Required for invoke Lambda function)**
 
 - `lambda:InvokeFunctionUrl` - Invoke Lambda function URL
+- `lambda:InvokeFunction` - Invoke Lambda function (required since Oct 2025 for function URLs with AWS_IAM auth)
 
 ## Prerequisites
 

--- a/src/packages/app-framework/src/credential-manager/index.ts
+++ b/src/packages/app-framework/src/credential-manager/index.ts
@@ -179,7 +179,7 @@ export class CredentialManager extends NestedStack {
   grantGetAppToken(grantee: IGrantable) {
     grantee.grantPrincipal.addToPrincipalPolicy(
       new PolicyStatement({
-        actions: ['lambda:InvokeFunctionUrl'],
+        actions: ['lambda:InvokeFunctionUrl', 'lambda:InvokeFunction'],
         effect: Effect.ALLOW,
         resources: [this.appTokenLambdaArn],
         conditions: {
@@ -194,7 +194,7 @@ export class CredentialManager extends NestedStack {
   grantGetInstallationAccessToken(grantee: IGrantable) {
     grantee.grantPrincipal.addToPrincipalPolicy(
       new PolicyStatement({
-        actions: ['lambda:InvokeFunctionUrl'],
+        actions: ['lambda:InvokeFunctionUrl', 'lambda:InvokeFunction'],
         effect: Effect.ALLOW,
         resources: [this.installationAccessLambdaArn],
         conditions: {
@@ -209,7 +209,7 @@ export class CredentialManager extends NestedStack {
   grantRefreshCachedData(grantee: IGrantable) {
     grantee.grantPrincipal.addToPrincipalPolicy(
       new PolicyStatement({
-        actions: ['lambda:InvokeFunctionUrl'],
+        actions: ['lambda:InvokeFunctionUrl', 'lambda:InvokeFunction'],
         effect: Effect.ALLOW,
         resources: [this.refreshCachedDataLambdaArn],
         conditions: {
@@ -224,7 +224,7 @@ export class CredentialManager extends NestedStack {
   grantGetInstallationRecord(grantee: IGrantable) {
     grantee.grantPrincipal.addToPrincipalPolicy(
       new PolicyStatement({
-        actions: ['lambda:InvokeFunctionUrl'],
+        actions: ['lambda:InvokeFunctionUrl', 'lambda:InvokeFunction'],
         effect: Effect.ALLOW,
         resources: [this.installationRecordLambdaArn],
         conditions: {
@@ -239,7 +239,7 @@ export class CredentialManager extends NestedStack {
   grantGetInstallations(grantee: IGrantable) {
     grantee.grantPrincipal.addToPrincipalPolicy(
       new PolicyStatement({
-        actions: ['lambda:InvokeFunctionUrl'],
+        actions: ['lambda:InvokeFunctionUrl', 'lambda:InvokeFunction'],
         effect: Effect.ALLOW,
         resources: [this.installationsLambdaArn],
         conditions: {


### PR DESCRIPTION
Per https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html, `lambda:InvokeFunction` is also necessary as of Oct 2025 for the AWS_IAM auth type.

Adding these permissions fixed the auth error I was hitting in my handlers